### PR TITLE
Support default_scope ordering by calling .unscoped

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -222,7 +222,7 @@ module ActiveRecord
           def bottom_item(except = nil)
             conditions = scope_condition
             conditions = "#{conditions} AND #{self.class.primary_key} != #{except.id}" if except
-            acts_as_list_class.find(:first, :conditions => conditions, :order => "#{position_column} DESC")
+            acts_as_list_class.unscoped.find(:first, :conditions => conditions, :order => "#{position_column} DESC")
           end
 
           # Forces item to assume the bottom position in the list.


### PR DESCRIPTION
Support default_scope ordering by calling .unscoped when retrieving the highest current position value for a model in the list.

Submitted as a pull request as requested in #11.
