### PR TITLE
Massive test refactorings.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,3 +10,5 @@ end
 require 'test/unit'
 require 'active_record'
 require "#{File.dirname(__FILE__)}/../init"
+
+require 'shared'

--- a/test/shared.rb
+++ b/test/shared.rb
@@ -1,0 +1,7 @@
+# Common shared behaviour.
+module Shared
+  autoload :List,           'shared_list'
+  autoload :ListSub,        'shared_list_sub'
+  autoload :ZeroBased,      'shared_zero_based'
+  autoload :ArrayScopeList, 'shared_array_scope_list'
+end

--- a/test/shared_array_scope_list.rb
+++ b/test/shared_array_scope_list.rb
@@ -1,0 +1,156 @@
+module Shared
+  module ArrayScopeList
+    def setup
+      (1..4).each { |counter| ArrayScopeListMixin.create! :pos => counter, :parent_id => 5, :parent_type => 'ParentClass' }
+    end
+
+    def test_reordering
+      assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(2).move_lower
+      assert_equal [1, 3, 2, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(2).move_higher
+      assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(1).move_to_bottom
+      assert_equal [2, 3, 4, 1], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(1).move_to_top
+      assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(2).move_to_bottom
+      assert_equal [1, 3, 4, 2], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(4).move_to_top
+      assert_equal [4, 1, 3, 2], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+    end
+
+    def test_move_to_bottom_with_next_to_last_item
+      assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+      ArrayScopeListMixin.find(3).move_to_bottom
+      assert_equal [1, 2, 4, 3], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+    end
+
+    def test_next_prev
+      assert_equal ArrayScopeListMixin.find(2), ArrayScopeListMixin.find(1).lower_item
+      assert_nil ArrayScopeListMixin.find(1).higher_item
+      assert_equal ArrayScopeListMixin.find(3), ArrayScopeListMixin.find(4).higher_item
+      assert_nil ArrayScopeListMixin.find(4).lower_item
+    end
+
+    def test_injection
+      item = ArrayScopeListMixin.new(:parent_id => 1, :parent_type => 'ParentClass')
+      assert_equal '"mixins"."parent_id" = 1 AND "mixins"."parent_type" = \'ParentClass\'', item.scope_condition
+      assert_equal "pos", item.position_column
+    end
+
+    def test_insert
+      new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
+      assert_equal 1, new.pos
+      assert new.first?
+      assert new.last?
+
+      new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
+      assert_equal 2, new.pos
+      assert !new.first?
+      assert new.last?
+
+      new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
+      assert_equal 3, new.pos
+      assert !new.first?
+      assert new.last?
+
+      new = ArrayScopeListMixin.create(:parent_id => 0, :parent_type => 'ParentClass')
+      assert_equal 1, new.pos
+      assert new.first?
+      assert new.last?
+    end
+
+    def test_insert_at
+      new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
+      assert_equal 1, new.pos
+
+      new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
+      assert_equal 2, new.pos
+
+      new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
+      assert_equal 3, new.pos
+
+      new4 = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
+      assert_equal 4, new4.pos
+
+      new4.insert_at(3)
+      assert_equal 3, new4.pos
+
+      new.reload
+      assert_equal 4, new.pos
+
+      new.insert_at(2)
+      assert_equal 2, new.pos
+
+      new4.reload
+      assert_equal 4, new4.pos
+
+      new5 = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
+      assert_equal 5, new5.pos
+
+      new5.insert_at(1)
+      assert_equal 1, new5.pos
+
+      new4.reload
+      assert_equal 5, new4.pos
+    end
+
+    def test_delete_middle
+      assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(2).destroy
+
+      assert_equal [1, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      assert_equal 1, ArrayScopeListMixin.find(1).pos
+      assert_equal 2, ArrayScopeListMixin.find(3).pos
+      assert_equal 3, ArrayScopeListMixin.find(4).pos
+
+      ArrayScopeListMixin.find(1).destroy
+
+      assert_equal [3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      assert_equal 1, ArrayScopeListMixin.find(3).pos
+      assert_equal 2, ArrayScopeListMixin.find(4).pos
+    end
+
+    def test_remove_from_list_should_then_fail_in_list?
+      assert_equal true, ArrayScopeListMixin.find(1).in_list?
+      ArrayScopeListMixin.find(1).remove_from_list
+      assert_equal false, ArrayScopeListMixin.find(1).in_list?
+    end
+
+    def test_remove_from_list_should_set_position_to_nil
+      assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(2).remove_from_list
+
+      assert_equal [2, 1, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      assert_equal 1,   ArrayScopeListMixin.find(1).pos
+      assert_equal nil, ArrayScopeListMixin.find(2).pos
+      assert_equal 2,   ArrayScopeListMixin.find(3).pos
+      assert_equal 3,   ArrayScopeListMixin.find(4).pos
+    end
+
+    def test_remove_before_destroy_does_not_shift_lower_items_twice
+      assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      ArrayScopeListMixin.find(2).remove_from_list
+      ArrayScopeListMixin.find(2).destroy
+
+      assert_equal [1, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+
+      assert_equal 1, ArrayScopeListMixin.find(1).pos
+      assert_equal 2, ArrayScopeListMixin.find(3).pos
+      assert_equal 3, ArrayScopeListMixin.find(4).pos
+    end
+  end
+end

--- a/test/shared_list.rb
+++ b/test/shared_list.rb
@@ -1,0 +1,222 @@
+module Shared
+  module List
+    def setup
+      (1..4).each { |counter| ListMixin.create! :pos => counter, :parent_id => 5 }
+    end
+
+    def test_reordering
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_lower
+      assert_equal [1, 3, 2, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_higher
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(1).move_to_bottom
+      assert_equal [2, 3, 4, 1], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(1).move_to_top
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_to_bottom
+      assert_equal [1, 3, 4, 2], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(4).move_to_top
+      assert_equal [4, 1, 3, 2], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+    end
+
+    def test_move_to_bottom_with_next_to_last_item
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+      ListMixin.find(3).move_to_bottom
+      assert_equal [1, 2, 4, 3], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+    end
+
+    def test_next_prev
+      assert_equal ListMixin.find(2), ListMixin.find(1).lower_item
+      assert_nil ListMixin.find(1).higher_item
+      assert_equal ListMixin.find(3), ListMixin.find(4).higher_item
+      assert_nil ListMixin.find(4).lower_item
+    end
+
+    def test_injection
+      item = ListMixin.new(:parent_id => 1)
+      assert_equal '"mixins"."parent_id" = 1', item.scope_condition
+      assert_equal "pos", item.position_column
+    end
+
+    def test_insert
+      new = ListMixin.create(:parent_id => 20)
+      assert_equal 1, new.pos
+      assert new.first?
+      assert new.last?
+
+      new = ListMixin.create(:parent_id => 20)
+      assert_equal 2, new.pos
+      assert !new.first?
+      assert new.last?
+
+      new = ListMixin.create(:parent_id => 20)
+      assert_equal 3, new.pos
+      assert !new.first?
+      assert new.last?
+
+      new = ListMixin.create(:parent_id => 0)
+      assert_equal 1, new.pos
+      assert new.first?
+      assert new.last?
+    end
+
+    def test_insert_at
+      new = ListMixin.create(:parent_id => 20)
+      assert_equal 1, new.pos
+
+      new = ListMixin.create(:parent_id => 20)
+      assert_equal 2, new.pos
+
+      new = ListMixin.create(:parent_id => 20)
+      assert_equal 3, new.pos
+
+      new4 = ListMixin.create(:parent_id => 20)
+      assert_equal 4, new4.pos
+
+      new4.insert_at(3)
+      assert_equal 3, new4.pos
+
+      new.reload
+      assert_equal 4, new.pos
+
+      new.insert_at(2)
+      assert_equal 2, new.pos
+
+      new4.reload
+      assert_equal 4, new4.pos
+
+      new5 = ListMixin.create(:parent_id => 20)
+      assert_equal 5, new5.pos
+
+      new5.insert_at(1)
+      assert_equal 1, new5.pos
+
+      new4.reload
+      assert_equal 5, new4.pos
+    end
+
+    def test_delete_middle
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).destroy
+
+      assert_equal [1, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      assert_equal 1, ListMixin.find(1).pos
+      assert_equal 2, ListMixin.find(3).pos
+      assert_equal 3, ListMixin.find(4).pos
+
+      ListMixin.find(1).destroy
+
+      assert_equal [3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      assert_equal 1, ListMixin.find(3).pos
+      assert_equal 2, ListMixin.find(4).pos
+    end
+
+    def test_with_string_based_scope
+      new = ListWithStringScopeMixin.create(:parent_id => 500)
+      assert_equal 1, new.pos
+      assert new.first?
+      assert new.last?
+    end
+
+    def test_nil_scope
+      new1, new2, new3 = ListMixin.create, ListMixin.create, ListMixin.create
+      new2.move_higher
+      assert_equal [new2, new1, new3], ListMixin.find(:all, :conditions => 'parent_id IS NULL', :order => 'pos')
+    end
+
+    def test_remove_from_list_should_then_fail_in_list?
+      assert_equal true, ListMixin.find(1).in_list?
+      ListMixin.find(1).remove_from_list
+      assert_equal false, ListMixin.find(1).in_list?
+    end
+
+    def test_remove_from_list_should_set_position_to_nil
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).remove_from_list
+
+      assert_equal [2, 1, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      assert_equal 1,   ListMixin.find(1).pos
+      assert_equal nil, ListMixin.find(2).pos
+      assert_equal 2,   ListMixin.find(3).pos
+      assert_equal 3,   ListMixin.find(4).pos
+    end
+
+    def test_remove_before_destroy_does_not_shift_lower_items_twice
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).remove_from_list
+      ListMixin.find(2).destroy
+
+      assert_equal [1, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      assert_equal 1, ListMixin.find(1).pos
+      assert_equal 2, ListMixin.find(3).pos
+      assert_equal 3, ListMixin.find(4).pos
+    end
+
+    def test_before_destroy_callbacks_do_not_update_position_to_nil_before_deleting_the_record
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      # We need to trigger all the before_destroy callbacks without actually
+      # destroying the record so we can see the affect the callbacks have on
+      # the record.
+      # NOTE: Hotfix for rails3 ActiveRecord
+      list = ListMixin.find(2)
+      if list.respond_to?(:run_callbacks)
+        # Refactored to work according to Rails3 ActiveRSupport Callbacks <http://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html>
+        list.run_callbacks :destroy, :before if rails_3
+        list.run_callbacks(:before_destroy) if !rails_3
+      else
+        list.send(:callback, :before_destroy)
+      end
+
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      assert_equal 1, ListMixin.find(1).pos
+      assert_equal 2, ListMixin.find(2).pos
+      assert_equal 2, ListMixin.find(3).pos
+      assert_equal 3, ListMixin.find(4).pos
+    end
+
+    def test_before_create_callback_adds_to_bottom
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      new = ListMixin.create(:parent_id => 5)
+      assert_equal 5, new.pos
+      assert !new.first?
+      assert new.last?
+
+      assert_equal [1, 2, 3, 4, 5], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+    end
+
+    def test_before_create_callback_adds_to_given_position
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      new = ListMixin.create(:pos => 1, :parent_id => 5)
+      assert_equal 1, new.pos
+      assert new.first?
+      assert !new.last?
+
+      assert_equal [5, 1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      new = ListMixin.create(:pos => 3, :parent_id => 5)
+      assert_equal 3, new.pos
+      assert !new.first?
+      assert !new.last?
+
+      assert_equal [5, 1, 6, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+    end
+  end
+end

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -1,0 +1,102 @@
+module Shared
+  module ListSub
+    def setup
+      (1..4).each { |i| ((i % 2 == 1) ? ListMixinSub1 : ListMixinSub2).create! :pos => i, :parent_id => 5000 }
+    end
+
+    def test_reordering
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_lower
+      assert_equal [1, 3, 2, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_higher
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      ListMixin.find(1).move_to_bottom
+      assert_equal [2, 3, 4, 1], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      ListMixin.find(1).move_to_top
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_to_bottom
+      assert_equal [1, 3, 4, 2], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      ListMixin.find(4).move_to_top
+      assert_equal [4, 1, 3, 2], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+    end
+
+    def test_move_to_bottom_with_next_to_last_item
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+      ListMixin.find(3).move_to_bottom
+      assert_equal [1, 2, 4, 3], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+    end
+
+    def test_next_prev
+      assert_equal ListMixin.find(2), ListMixin.find(1).lower_item
+      assert_nil ListMixin.find(1).higher_item
+      assert_equal ListMixin.find(3), ListMixin.find(4).higher_item
+      assert_nil ListMixin.find(4).lower_item
+    end
+
+    def test_injection
+      item = ListMixin.new("parent_id"=>1)
+      assert_equal '"mixins"."parent_id" = 1', item.scope_condition
+      assert_equal "pos", item.position_column
+    end
+
+    def test_insert_at
+      new = ListMixin.create("parent_id" => 20)
+      assert_equal 1, new.pos
+
+      new = ListMixinSub1.create("parent_id" => 20)
+      assert_equal 2, new.pos
+
+      new = ListMixinSub2.create("parent_id" => 20)
+      assert_equal 3, new.pos
+
+      new4 = ListMixin.create("parent_id" => 20)
+      assert_equal 4, new4.pos
+
+      new4.insert_at(3)
+      assert_equal 3, new4.pos
+
+      new.reload
+      assert_equal 4, new.pos
+
+      new.insert_at(2)
+      assert_equal 2, new.pos
+
+      new4.reload
+      assert_equal 4, new4.pos
+
+      new5 = ListMixinSub1.create("parent_id" => 20)
+      assert_equal 5, new5.pos
+
+      new5.insert_at(1)
+      assert_equal 1, new5.pos
+
+      new4.reload
+      assert_equal 5, new4.pos
+    end
+
+    def test_delete_middle
+      assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).destroy
+
+      assert_equal [1, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      assert_equal 1, ListMixin.find(1).pos
+      assert_equal 2, ListMixin.find(3).pos
+      assert_equal 3, ListMixin.find(4).pos
+
+      ListMixin.find(1).destroy
+
+      assert_equal [3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
+
+      assert_equal 1, ListMixin.find(3).pos
+      assert_equal 2, ListMixin.find(4).pos
+    end
+  end
+end

--- a/test/shared_zero_based.rb
+++ b/test/shared_zero_based.rb
@@ -1,0 +1,86 @@
+module Shared
+  module ZeroBased
+    def setup
+       (1..4).each { |counter| ZeroBasedMixin.create! :pos => counter, :parent_id => 5 }
+    end
+
+    def test_insert
+      new = ZeroBasedMixin.create(:parent_id => 20)
+      assert_equal 0, new.pos
+      assert new.first?
+      assert new.last?
+
+      new = ZeroBasedMixin.create(:parent_id => 20)
+      assert_equal 1, new.pos
+      assert !new.first?
+      assert new.last?
+
+      new = ZeroBasedMixin.create(:parent_id => 20)
+      assert_equal 2, new.pos
+      assert !new.first?
+      assert new.last?
+
+      new = ZeroBasedMixin.create(:parent_id => 0)
+      assert_equal 0, new.pos
+      assert new.first?
+      assert new.last?
+    end
+
+    def test_reordering
+      assert_equal [1, 2, 3, 4], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_lower
+      assert_equal [1, 3, 2, 4], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_higher
+      assert_equal [1, 2, 3, 4], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(1).move_to_bottom
+      assert_equal [2, 3, 4, 1], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(1).move_to_top
+      assert_equal [1, 2, 3, 4], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(2).move_to_bottom
+      assert_equal [1, 3, 4, 2], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+
+      ListMixin.find(4).move_to_top
+      assert_equal [4, 1, 3, 2], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
+    end
+
+    def test_insert_at
+      new = ZeroBasedMixin.create(:parent_id => 20)
+      assert_equal 0, new.pos
+
+      new = ZeroBasedMixin.create(:parent_id => 20)
+      assert_equal 1, new.pos
+
+      new = ZeroBasedMixin.create(:parent_id => 20)
+      assert_equal 2, new.pos
+
+      new4 = ZeroBasedMixin.create(:parent_id => 20)
+      assert_equal 3, new4.pos
+
+      new4.insert_at(2)
+      assert_equal 2, new4.pos
+
+      new.reload
+      assert_equal 3, new.pos
+
+      new.insert_at(2)
+      assert_equal 2, new.pos
+
+      new4.reload
+      assert_equal 3, new4.pos
+
+      new5 = ListMixin.create(:parent_id => 20)
+      assert_equal 4, new5.pos
+
+      new5.insert_at(1)
+      assert_equal 1, new5.pos
+
+      new4.reload
+      assert_equal 4, new4.pos
+    end
+  end
+end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -74,93 +74,8 @@ class ActsAsListTestCase < Test::Unit::TestCase
   end
 end
 
-module SharedZeroBasedTest
-  def setup
-     (1..4).each { |counter| ZeroBasedMixin.create! :pos => counter, :parent_id => 5 }
-  end
-
-  def test_insert
-    new = ZeroBasedMixin.create(:parent_id => 20)
-    assert_equal 0, new.pos
-    assert new.first?
-    assert new.last?
-
-    new = ZeroBasedMixin.create(:parent_id => 20)
-    assert_equal 1, new.pos
-    assert !new.first?
-    assert new.last?
-
-    new = ZeroBasedMixin.create(:parent_id => 20)
-    assert_equal 2, new.pos
-    assert !new.first?
-    assert new.last?
-
-    new = ZeroBasedMixin.create(:parent_id => 0)
-    assert_equal 0, new.pos
-    assert new.first?
-    assert new.last?
-  end
-
-  def test_reordering
-    assert_equal [1, 2, 3, 4], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_lower
-    assert_equal [1, 3, 2, 4], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_higher
-    assert_equal [1, 2, 3, 4], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(1).move_to_bottom
-    assert_equal [2, 3, 4, 1], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(1).move_to_top
-    assert_equal [1, 2, 3, 4], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_to_bottom
-    assert_equal [1, 3, 4, 2], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(4).move_to_top
-    assert_equal [4, 1, 3, 2], ZeroBasedMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-  end
-
-  def test_insert_at
-    new = ZeroBasedMixin.create(:parent_id => 20)
-    assert_equal 0, new.pos
-
-    new = ZeroBasedMixin.create(:parent_id => 20)
-    assert_equal 1, new.pos
-
-    new = ZeroBasedMixin.create(:parent_id => 20)
-    assert_equal 2, new.pos
-
-    new4 = ZeroBasedMixin.create(:parent_id => 20)
-    assert_equal 3, new4.pos
-
-    new4.insert_at(2)
-    assert_equal 2, new4.pos
-
-    new.reload
-    assert_equal 3, new.pos
-
-    new.insert_at(2)
-    assert_equal 2, new.pos
-
-    new4.reload
-    assert_equal 3, new4.pos
-
-    new5 = ListMixin.create(:parent_id => 20)
-    assert_equal 4, new5.pos
-
-    new5.insert_at(1)
-    assert_equal 1, new5.pos
-
-    new4.reload
-    assert_equal 4, new4.pos
-  end
-end
-
 class ZeroBasedTest < ActsAsListTestCase
-  include SharedZeroBasedTest
+  include Shared::ZeroBased
 
   def setup
     setup_db
@@ -169,7 +84,7 @@ class ZeroBasedTest < ActsAsListTestCase
 end
 
 class ZeroBasedTestWithDefault < ActsAsListTestCase
-  include SharedZeroBasedTest
+  include Shared::ZeroBased
 
   def setup
     setup_db_with_default
@@ -177,229 +92,8 @@ class ZeroBasedTestWithDefault < ActsAsListTestCase
   end
 end
 
-module SharedListTest
-  def setup
-    (1..4).each { |counter| ListMixin.create! :pos => counter, :parent_id => 5 }
-  end
-
-  def test_reordering
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_lower
-    assert_equal [1, 3, 2, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_higher
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(1).move_to_bottom
-    assert_equal [2, 3, 4, 1], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(1).move_to_top
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_to_bottom
-    assert_equal [1, 3, 4, 2], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(4).move_to_top
-    assert_equal [4, 1, 3, 2], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-  end
-
-  def test_move_to_bottom_with_next_to_last_item
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-    ListMixin.find(3).move_to_bottom
-    assert_equal [1, 2, 4, 3], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-  end
-
-  def test_next_prev
-    assert_equal ListMixin.find(2), ListMixin.find(1).lower_item
-    assert_nil ListMixin.find(1).higher_item
-    assert_equal ListMixin.find(3), ListMixin.find(4).higher_item
-    assert_nil ListMixin.find(4).lower_item
-  end
-
-  def test_injection
-    item = ListMixin.new(:parent_id => 1)
-    assert_equal '"mixins"."parent_id" = 1', item.scope_condition
-    assert_equal "pos", item.position_column
-  end
-
-  def test_insert
-    new = ListMixin.create(:parent_id => 20)
-    assert_equal 1, new.pos
-    assert new.first?
-    assert new.last?
-
-    new = ListMixin.create(:parent_id => 20)
-    assert_equal 2, new.pos
-    assert !new.first?
-    assert new.last?
-
-    new = ListMixin.create(:parent_id => 20)
-    assert_equal 3, new.pos
-    assert !new.first?
-    assert new.last?
-
-    new = ListMixin.create(:parent_id => 0)
-    assert_equal 1, new.pos
-    assert new.first?
-    assert new.last?
-  end
-
-  def test_insert_at
-    new = ListMixin.create(:parent_id => 20)
-    assert_equal 1, new.pos
-
-    new = ListMixin.create(:parent_id => 20)
-    assert_equal 2, new.pos
-
-    new = ListMixin.create(:parent_id => 20)
-    assert_equal 3, new.pos
-
-    new4 = ListMixin.create(:parent_id => 20)
-    assert_equal 4, new4.pos
-
-    new4.insert_at(3)
-    assert_equal 3, new4.pos
-
-    new.reload
-    assert_equal 4, new.pos
-
-    new.insert_at(2)
-    assert_equal 2, new.pos
-
-    new4.reload
-    assert_equal 4, new4.pos
-
-    new5 = ListMixin.create(:parent_id => 20)
-    assert_equal 5, new5.pos
-
-    new5.insert_at(1)
-    assert_equal 1, new5.pos
-
-    new4.reload
-    assert_equal 5, new4.pos
-  end
-
-  def test_delete_middle
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).destroy
-
-    assert_equal [1, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    assert_equal 1, ListMixin.find(1).pos
-    assert_equal 2, ListMixin.find(3).pos
-    assert_equal 3, ListMixin.find(4).pos
-
-    ListMixin.find(1).destroy
-
-    assert_equal [3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    assert_equal 1, ListMixin.find(3).pos
-    assert_equal 2, ListMixin.find(4).pos
-  end
-
-  def test_with_string_based_scope
-    new = ListWithStringScopeMixin.create(:parent_id => 500)
-    assert_equal 1, new.pos
-    assert new.first?
-    assert new.last?
-  end
-
-  def test_nil_scope
-    new1, new2, new3 = ListMixin.create, ListMixin.create, ListMixin.create
-    new2.move_higher
-    assert_equal [new2, new1, new3], ListMixin.find(:all, :conditions => 'parent_id IS NULL', :order => 'pos')
-  end
-
-  def test_remove_from_list_should_then_fail_in_list?
-    assert_equal true, ListMixin.find(1).in_list?
-    ListMixin.find(1).remove_from_list
-    assert_equal false, ListMixin.find(1).in_list?
-  end
-
-  def test_remove_from_list_should_set_position_to_nil
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).remove_from_list
-
-    assert_equal [2, 1, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    assert_equal 1,   ListMixin.find(1).pos
-    assert_equal nil, ListMixin.find(2).pos
-    assert_equal 2,   ListMixin.find(3).pos
-    assert_equal 3,   ListMixin.find(4).pos
-  end
-
-  def test_remove_before_destroy_does_not_shift_lower_items_twice
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).remove_from_list
-    ListMixin.find(2).destroy
-
-    assert_equal [1, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    assert_equal 1, ListMixin.find(1).pos
-    assert_equal 2, ListMixin.find(3).pos
-    assert_equal 3, ListMixin.find(4).pos
-  end
-
-  def test_before_destroy_callbacks_do_not_update_position_to_nil_before_deleting_the_record
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    # We need to trigger all the before_destroy callbacks without actually
-    # destroying the record so we can see the affect the callbacks have on
-    # the record.
-    # NOTE: Hotfix for rails3 ActiveRecord
-    list = ListMixin.find(2)
-    if list.respond_to?(:run_callbacks)
-      # Refactored to work according to Rails3 ActiveRSupport Callbacks <http://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html>
-      list.run_callbacks :destroy, :before if rails_3
-      list.run_callbacks(:before_destroy) if !rails_3
-    else
-      list.send(:callback, :before_destroy)
-    end
-
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    assert_equal 1, ListMixin.find(1).pos
-    assert_equal 2, ListMixin.find(2).pos
-    assert_equal 2, ListMixin.find(3).pos
-    assert_equal 3, ListMixin.find(4).pos
-  end
-
-  def test_before_create_callback_adds_to_bottom
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    new = ListMixin.create(:parent_id => 5)
-    assert_equal 5, new.pos
-    assert !new.first?
-    assert new.last?
-
-    assert_equal [1, 2, 3, 4, 5], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-  end
-
-  def test_before_create_callback_adds_to_given_position
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    new = ListMixin.create(:pos => 1, :parent_id => 5)
-    assert_equal 1, new.pos
-    assert new.first?
-    assert !new.last?
-
-    assert_equal [5, 1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-
-    new = ListMixin.create(:pos => 3, :parent_id => 5)
-    assert_equal 3, new.pos
-    assert !new.first?
-    assert !new.last?
-
-    assert_equal [5, 1, 6, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
-  end
-end
-
 class ListTest < ActsAsListTestCase
-  include SharedListTest
+  include Shared::List
 
   def setup
     setup_db
@@ -408,7 +102,7 @@ class ListTest < ActsAsListTestCase
 end
 
 class ListTestWithDefault < ActsAsListTestCase
-  include SharedListTest
+  include Shared::List
 
   def setup
     setup_db_with_default
@@ -416,109 +110,8 @@ class ListTestWithDefault < ActsAsListTestCase
   end
 end
 
-module SharedListSubTest
-  def setup
-    (1..4).each { |i| ((i % 2 == 1) ? ListMixinSub1 : ListMixinSub2).create! :pos => i, :parent_id => 5000 }
-  end
-
-  def test_reordering
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_lower
-    assert_equal [1, 3, 2, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_higher
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    ListMixin.find(1).move_to_bottom
-    assert_equal [2, 3, 4, 1], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    ListMixin.find(1).move_to_top
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).move_to_bottom
-    assert_equal [1, 3, 4, 2], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    ListMixin.find(4).move_to_top
-    assert_equal [4, 1, 3, 2], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-  end
-
-  def test_move_to_bottom_with_next_to_last_item
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-    ListMixin.find(3).move_to_bottom
-    assert_equal [1, 2, 4, 3], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-  end
-
-  def test_next_prev
-    assert_equal ListMixin.find(2), ListMixin.find(1).lower_item
-    assert_nil ListMixin.find(1).higher_item
-    assert_equal ListMixin.find(3), ListMixin.find(4).higher_item
-    assert_nil ListMixin.find(4).lower_item
-  end
-
-  def test_injection
-    item = ListMixin.new("parent_id"=>1)
-    assert_equal '"mixins"."parent_id" = 1', item.scope_condition
-    assert_equal "pos", item.position_column
-  end
-
-  def test_insert_at
-    new = ListMixin.create("parent_id" => 20)
-    assert_equal 1, new.pos
-
-    new = ListMixinSub1.create("parent_id" => 20)
-    assert_equal 2, new.pos
-
-    new = ListMixinSub2.create("parent_id" => 20)
-    assert_equal 3, new.pos
-
-    new4 = ListMixin.create("parent_id" => 20)
-    assert_equal 4, new4.pos
-
-    new4.insert_at(3)
-    assert_equal 3, new4.pos
-
-    new.reload
-    assert_equal 4, new.pos
-
-    new.insert_at(2)
-    assert_equal 2, new.pos
-
-    new4.reload
-    assert_equal 4, new4.pos
-
-    new5 = ListMixinSub1.create("parent_id" => 20)
-    assert_equal 5, new5.pos
-
-    new5.insert_at(1)
-    assert_equal 1, new5.pos
-
-    new4.reload
-    assert_equal 5, new4.pos
-  end
-
-  def test_delete_middle
-    assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    ListMixin.find(2).destroy
-
-    assert_equal [1, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    assert_equal 1, ListMixin.find(1).pos
-    assert_equal 2, ListMixin.find(3).pos
-    assert_equal 3, ListMixin.find(4).pos
-
-    ListMixin.find(1).destroy
-
-    assert_equal [3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5000', :order => 'pos').map(&:id)
-
-    assert_equal 1, ListMixin.find(3).pos
-    assert_equal 2, ListMixin.find(4).pos
-  end
-end
-
 class ListSubTest < ActsAsListTestCase
-  include SharedListSubTest
+  include Shared::ListSub
 
   def setup
     setup_db
@@ -527,7 +120,7 @@ class ListSubTest < ActsAsListTestCase
 end
 
 class ListSubTestWithDefault < ActsAsListTestCase
-  include SharedListSubTest
+  include Shared::ListSub
 
   def setup
     setup_db_with_default
@@ -535,163 +128,8 @@ class ListSubTestWithDefault < ActsAsListTestCase
   end
 end
 
-module SharedArrayScopeListTest
-  def setup
-    (1..4).each { |counter| ArrayScopeListMixin.create! :pos => counter, :parent_id => 5, :parent_type => 'ParentClass' }
-  end
-
-  def test_reordering
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(2).move_lower
-    assert_equal [1, 3, 2, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(2).move_higher
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(1).move_to_bottom
-    assert_equal [2, 3, 4, 1], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(1).move_to_top
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(2).move_to_bottom
-    assert_equal [1, 3, 4, 2], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(4).move_to_top
-    assert_equal [4, 1, 3, 2], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-  end
-
-  def test_move_to_bottom_with_next_to_last_item
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-    ArrayScopeListMixin.find(3).move_to_bottom
-    assert_equal [1, 2, 4, 3], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-  end
-
-  def test_next_prev
-    assert_equal ArrayScopeListMixin.find(2), ArrayScopeListMixin.find(1).lower_item
-    assert_nil ArrayScopeListMixin.find(1).higher_item
-    assert_equal ArrayScopeListMixin.find(3), ArrayScopeListMixin.find(4).higher_item
-    assert_nil ArrayScopeListMixin.find(4).lower_item
-  end
-
-  def test_injection
-    item = ArrayScopeListMixin.new(:parent_id => 1, :parent_type => 'ParentClass')
-    assert_equal '"mixins"."parent_id" = 1 AND "mixins"."parent_type" = \'ParentClass\'', item.scope_condition
-    assert_equal "pos", item.position_column
-  end
-
-  def test_insert
-    new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
-    assert_equal 1, new.pos
-    assert new.first?
-    assert new.last?
-
-    new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
-    assert_equal 2, new.pos
-    assert !new.first?
-    assert new.last?
-
-    new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
-    assert_equal 3, new.pos
-    assert !new.first?
-    assert new.last?
-
-    new = ArrayScopeListMixin.create(:parent_id => 0, :parent_type => 'ParentClass')
-    assert_equal 1, new.pos
-    assert new.first?
-    assert new.last?
-  end
-
-  def test_insert_at
-    new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
-    assert_equal 1, new.pos
-
-    new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
-    assert_equal 2, new.pos
-
-    new = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
-    assert_equal 3, new.pos
-
-    new4 = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
-    assert_equal 4, new4.pos
-
-    new4.insert_at(3)
-    assert_equal 3, new4.pos
-
-    new.reload
-    assert_equal 4, new.pos
-
-    new.insert_at(2)
-    assert_equal 2, new.pos
-
-    new4.reload
-    assert_equal 4, new4.pos
-
-    new5 = ArrayScopeListMixin.create(:parent_id => 20, :parent_type => 'ParentClass')
-    assert_equal 5, new5.pos
-
-    new5.insert_at(1)
-    assert_equal 1, new5.pos
-
-    new4.reload
-    assert_equal 5, new4.pos
-  end
-
-  def test_delete_middle
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(2).destroy
-
-    assert_equal [1, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    assert_equal 1, ArrayScopeListMixin.find(1).pos
-    assert_equal 2, ArrayScopeListMixin.find(3).pos
-    assert_equal 3, ArrayScopeListMixin.find(4).pos
-
-    ArrayScopeListMixin.find(1).destroy
-
-    assert_equal [3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    assert_equal 1, ArrayScopeListMixin.find(3).pos
-    assert_equal 2, ArrayScopeListMixin.find(4).pos
-  end
-
-  def test_remove_from_list_should_then_fail_in_list?
-    assert_equal true, ArrayScopeListMixin.find(1).in_list?
-    ArrayScopeListMixin.find(1).remove_from_list
-    assert_equal false, ArrayScopeListMixin.find(1).in_list?
-  end
-
-  def test_remove_from_list_should_set_position_to_nil
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(2).remove_from_list
-
-    assert_equal [2, 1, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    assert_equal 1,   ArrayScopeListMixin.find(1).pos
-    assert_equal nil, ArrayScopeListMixin.find(2).pos
-    assert_equal 2,   ArrayScopeListMixin.find(3).pos
-    assert_equal 3,   ArrayScopeListMixin.find(4).pos
-  end
-
-  def test_remove_before_destroy_does_not_shift_lower_items_twice
-    assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    ArrayScopeListMixin.find(2).remove_from_list
-    ArrayScopeListMixin.find(2).destroy
-
-    assert_equal [1, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
-
-    assert_equal 1, ArrayScopeListMixin.find(1).pos
-    assert_equal 2, ArrayScopeListMixin.find(3).pos
-    assert_equal 3, ArrayScopeListMixin.find(4).pos
-  end
-end
-
 class ArrayScopeListTest < ActsAsListTestCase
-  include SharedArrayScopeListTest
+  include Shared::ArrayScopeList
 
   def setup
     setup_db
@@ -700,7 +138,7 @@ class ArrayScopeListTest < ActsAsListTestCase
 end
 
 class ArrayScopeListTestWithDefault < ActsAsListTestCase
-  include SharedArrayScopeListTest
+  include Shared::ArrayScopeList
 
   def setup
     setup_db_with_default


### PR DESCRIPTION
According to `flay` there was much duplication in test code. This isn't bad by default but it makes `test_list.rb` almost unreadable. At least for me.

With `test/unit` you can split up duplicate test code into modules. This killed many lines:
### Before
- test lines: `1355`
- flay score: `6268`
- rake: `71 tests, 439 assertions, 0 failures, 0 errors`
  </pre>
### After
- test lines: `816`
- flay score: `2272`
- rake: `71 tests, 439 assertions, 0 failures, 0 errors`
### Future

`flay` still reports similiar code which can be refactored easily but I am not sure if you accept that huge pull request ;)

<pre>
$ flay test/ | less
Total score (lower is better) = 2272


1) Similar code found in :defn (mass = 720)
  test/shared_list_sub.rb:7
  test/shared_list.rb:7
  test/shared_zero_based.rb:29
  test/shared_array_scope_list.rb:7

2) Similar code found in :defn (mass = 354)
  test/shared_list_sub.rb:83
  test/shared_list.rb:105
  test/shared_array_scope_list.rb:105

3) Similar code found in :defn (mass = 252)
  test/shared_list.rb:70
  test/shared_zero_based.rb:51

4) Similar code found in :defn (mass = 196)
  test/shared_list.rb:48
  test/shared_zero_based.rb:7

5) Similar code found in :defn (mass = 172)
  test/shared_list.rb:143
  test/shared_array_scope_list.rb:130

6) Similar code found in :defn (mass = 164)
  test/shared_list.rb:156
  test/shared_array_scope_list.rb:143

7) Similar code found in :defn (mass = 150)
  test/shared_list_sub.rb:29
  test/shared_list.rb:29
  test/shared_array_scope_list.rb:29

8) Similar code found in :defn (mass = 132)
  test/shared_list_sub.rb:35
  test/shared_list.rb:35
  test/shared_array_scope_list.rb:35
</pre>


Please follow each commit if the result (Files Changed) is overwhelming.

If you have questions please drop a line :)
