### PR TITLE
Use before validate instead of before create

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -75,7 +75,7 @@ module ActiveRecord
             #{scope_condition_method}
 
             after_destroy :decrement_positions_on_lower_items
-            before_create  :add_to_list_bottom
+            before_validation :add_to_list_bottom, :on => :create
           EOV
         end
       end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -52,6 +52,11 @@ class ListMixinSub1 < ListMixin
 end
 
 class ListMixinSub2 < ListMixin
+  if rails_3
+    validates :pos, :presence => true
+  else
+    validates_presence_of :pos
+  end
 end
 
 class ListWithStringScopeMixin < ActiveRecord::Base


### PR DESCRIPTION
In addition to having not null for column in database we could have rails validation for presence of column. However if position is assigned after validation,  then validation would not pass and record would not be saved.

Changed both code and spec, however additional changes may be required for older versions of rails, I am not sure about callback syntax for old rails versions, probably will need any conditional there.
