### PR TITLE
update ActiveRecord class eval to support ActiveSupport on_load

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,2 +1,4 @@
 $:.unshift "#{File.dirname(__FILE__)}/lib"
 require 'acts_as_list'
+
+ActsAsList::Railtie.insert

--- a/lib/acts_as_list.rb
+++ b/lib/acts_as_list.rb
@@ -1,2 +1,22 @@
 require 'acts_as_list/active_record/acts/list'
-ActiveRecord::Base.class_eval { include ActiveRecord::Acts::List }
+
+module ActsAsList
+  if defined? Rails::Railtie
+    require 'rails'
+    class Railtie < Rails::Railtie
+      initializer 'acts_as_list.insert_into_active_record' do
+        ActiveSupport.on_load :active_record do
+          ActsAsList::Railtie.insert
+        end
+      end
+    end
+  end
+
+  class Railtie
+    def self.insert
+      if defined?(ActiveRecord)
+        ActiveRecord::Base.send(:include, ActiveRecord::Acts::List)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When using acts_as_list on Heroku I was getting error on assets precompile as described in http://devcenter.heroku.com/articles/rails3x-asset-pipeline-cedar#troubleshooting

It was because the gem was not taking care of initialize_on_precompile Rails 3.1 new assets setup.

This pull request fix that.

Thanks.
