### PR TITLE
Add installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 
 This `acts_as` extension provides the capabilities for sorting and reordering a number of objects in a list. The class that has this specified needs to have a `position` column defined as an integer on the mapped database table.
 
+## Installation
+
+In your Gemfile:
+
+    gem 'acts_as_list'
+
+Or, from the command line:
+
+    gem install acts_as_list
+
+Then, as necessary in your source file(s):
+
+    require 'acts_as_list'
 
 ## Example
 


### PR DESCRIPTION
Because there weren't any installation instructions in the README, and because the project is still marked as a fork from rails, I incorrectly assumed that I had to specify the git repository in my Gemfile to get your version of the gem.  This commit adds to the README to clarify that it is indeed as easy as `gem install acts_as_list`.  Hopefully this saves a few minutes for someone else.
