### PR TITLE
Delete items and keep positions in tact

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -91,6 +91,13 @@ module ActiveRecord
           insert_at_position(position)
         end
 
+        # Delete the item and reorder positions
+        def delete
+          position = self.send(position_column).to_i
+          super
+          decrement_positions_on_lower_items position
+        end
+
         # Swap positions with the next lower item, if one exists.
         def move_lower
           return unless lower_item

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -235,6 +235,20 @@ class DefaultScopedTest < ActsAsListTestCase
     assert_equal 4, new4.pos
   end
 
+  def test_delete
+    DefaultScopedMixin.find(1).delete
+    assert_equal [1, 2, 3], DefaultScopedMixin.find(:all).map(&:pos)
+    
+    DefaultScopedMixin.find(3).delete
+    assert_equal [1, 2], DefaultScopedMixin.find(:all).map(&:pos)
+    
+    DefaultScopedMixin.find(4).delete
+    assert_equal [1], DefaultScopedMixin.find(:all).map(&:pos)
+    
+    DefaultScopedMixin.find(2).delete
+    assert_equal [], DefaultScopedMixin.find(:all).map(&:pos)
+  end
+
 end
 
 #class TopAdditionMixin < Mixin


### PR DESCRIPTION
Added a delete method which deletes the current item and decreases the position of the following items.
