### PR TITLE
Prevent SQL error when position_column is not unique

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -224,7 +224,7 @@ module ActiveRecord
           def bottom_item(except = nil)
             conditions = scope_condition
             conditions = "#{conditions} AND #{self.class.primary_key} != #{except.id}" if except
-            acts_as_list_class.unscoped.find(:first, :conditions => conditions, :order => "#{position_column} DESC")
+            acts_as_list_class.unscoped.find(:first, :conditions => conditions, :order => "#{acts_as_list_class.table_name}.#{position_column} DESC")
           end
 
           # Forces item to assume the bottom position in the list.


### PR DESCRIPTION
I was getting "Mysql2::Error: Column 'position' in order clause is
ambiguous ..." because I had a column in another table which shared the
name of the position column.
