### PR TITLE
initialize gem

### DIFF
--- a/lib/acts_as_list.rb
+++ b/lib/acts_as_list.rb
@@ -21,4 +21,4 @@ module ActsAsList
   end
 end
 
-ActsAsList::Railtie.insert unless defined?(Rails)
+ActsAsList::Railtie.insert


### PR DESCRIPTION
Adding initialization of the gem.
init.rb `ActsAsList::Railtie.insert` line is not invoked when using this gem is loaded.
