### PR TITLE
Fix for default_scope with where clauses

### DIFF
--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -72,7 +72,7 @@ end
 
 class DefaultScopedWhereMixin < Mixin
   acts_as_list :column => "pos"
-  default_scope { order('pos ASC').where(active: true) }
+  default_scope { order('pos ASC').where(:active => true) }
 end
 
 class TopAdditionMixin < Mixin
@@ -279,25 +279,25 @@ class DefaultScopedWhereTest < ActsAsListTestCase
   end
 
   def test_reordering
-    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(active: false).map(&:id)
+    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).map(&:id)
 
-    DefaultScopedWhereMixin.where(active: false).find(2).move_lower
-    assert_equal [1, 3, 2, 4], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(2).move_lower
+    assert_equal [1, 3, 2, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
 
-    DefaultScopedWhereMixin.where(active: false).find(2).move_higher
-    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(2).move_higher
+    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
 
-    DefaultScopedWhereMixin.where(active: false).find(1).move_to_bottom
-    assert_equal [2, 3, 4, 1], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(1).move_to_bottom
+    assert_equal [2, 3, 4, 1], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
 
-    DefaultScopedWhereMixin.where(active: false).find(1).move_to_top
-    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(1).move_to_top
+    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
 
-    DefaultScopedWhereMixin.where(active: false).find(2).move_to_bottom
-    assert_equal [1, 3, 4, 2], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(2).move_to_bottom
+    assert_equal [1, 3, 4, 2], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
 
-    DefaultScopedWhereMixin.where(active: false).find(4).move_to_top
-    assert_equal [4, 1, 3, 2], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(4).move_to_top
+    assert_equal [4, 1, 3, 2], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
   end
 
   def test_insert_at
@@ -336,15 +336,15 @@ class DefaultScopedWhereTest < ActsAsListTestCase
   end
 
   def test_update_position
-    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(active: false).find(2).update_attribute(:pos, 4)
-    assert_equal [1, 3, 4, 2], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(active: false).find(2).update_attribute(:pos, 2)
-    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(active: false).find(1).update_attribute(:pos, 4)
-    assert_equal [2, 3, 4, 1], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(active: false).find(1).update_attribute(:pos, 1)
-    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(active: false).find(:all).map(&:id)
+    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(2).update_attribute(:pos, 4)
+    assert_equal [1, 3, 4, 2], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(2).update_attribute(:pos, 2)
+    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(1).update_attribute(:pos, 4)
+    assert_equal [2, 3, 4, 1], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
+    DefaultScopedWhereMixin.where(:active => false).find(1).update_attribute(:pos, 1)
+    assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
   end
 
 end


### PR DESCRIPTION
As you said [in this comment](https://github.com/swanandp/acts_as_list/issues/11#issuecomment-1806514) if `default_scope` of any model includes `WHERE` clauses your code will break. I've tried to add unscoped for every `find` and `update_all` queries and it seems to fix this (wrong) behavior.

I've added some tests and the change doesn't break existing ones, so I hope this can be merged.
