### PR TITLE
Replaced usage of update_attribute with update_attribute! 

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -136,20 +136,20 @@ module ActiveRecord
         def remove_from_list
           if in_list?
             decrement_positions_on_lower_items
-            update_attribute position_column, nil
+            update_attributes! position_column => nil
           end
         end
 
         # Increase the position of this item without adjusting the rest of the list.
         def increment_position
           return unless in_list?
-          update_attribute position_column, self.send(position_column).to_i + 1
+          update_attributes! position_column => self.send(position_column).to_i + 1
         end
 
         # Decrease the position of this item without adjusting the rest of the list.
         def decrement_position
           return unless in_list?
-          update_attribute position_column, self.send(position_column).to_i - 1
+          update_attributes! position_column => self.send(position_column).to_i - 1
         end
 
         # Return +true+ if this object is the first in the list.
@@ -230,12 +230,12 @@ module ActiveRecord
 
           # Forces item to assume the bottom position in the list.
           def assume_bottom_position
-            update_attribute(position_column, bottom_position_in_list(self).to_i + 1)
+            update_attributes!(position_column => bottom_position_in_list(self).to_i + 1)
           end
 
           # Forces item to assume the top position in the list.
           def assume_top_position
-            update_attribute(position_column, acts_as_list_top)
+            update_attributes!(position_column => acts_as_list_top)
           end
 
           # This has the effect of moving all the higher items up one.
@@ -307,14 +307,14 @@ module ActiveRecord
             else
               increment_positions_on_lower_items(position)
             end
-            self.update_attribute(position_column, position)
+            self.update_attributes!(position_column => position)
           end
 
           # used by insert_at_position instead of remove_from_list, as postgresql raises error if position_column has non-null constraint
           def store_at_0
             if in_list?
               old_position = send(position_column).to_i
-              update_attribute(position_column, 0)
+              update_attributes!(position_column => 0)
               decrement_positions_on_lower_items(old_position)
             end
           end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -243,13 +243,13 @@ class DefaultScopedTest < ActsAsListTestCase
 
   def test_update_position
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(2).update_attribute(:pos, 4)
+    DefaultScopedMixin.find(2).update_attributes!(:pos => 4)
     assert_equal [1, 3, 4, 2], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(2).update_attribute(:pos, 2)
+    DefaultScopedMixin.find(2).update_attributes!(:pos => 2)
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(1).update_attribute(:pos, 4)
+    DefaultScopedMixin.find(1).update_attributes!(:pos => 4)
     assert_equal [2, 3, 4, 1], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(1).update_attribute(:pos, 1)
+    DefaultScopedMixin.find(1).update_attributes!(:pos => 1)
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
   end
 
@@ -337,13 +337,13 @@ class DefaultScopedWhereTest < ActsAsListTestCase
 
   def test_update_position
     assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(2).update_attribute(:pos, 4)
+    DefaultScopedWhereMixin.where(:active => false).find(2).update_attributes!(:pos => 4)
     assert_equal [1, 3, 4, 2], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(2).update_attribute(:pos, 2)
+    DefaultScopedWhereMixin.where(:active => false).find(2).update_attributes!(:pos => 2)
     assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(1).update_attribute(:pos, 4)
+    DefaultScopedWhereMixin.where(:active => false).find(1).update_attributes!(:pos => 4)
     assert_equal [2, 3, 4, 1], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(1).update_attribute(:pos, 1)
+    DefaultScopedWhereMixin.where(:active => false).find(1).update_attributes!(:pos => 1)
     assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
   end
 


### PR DESCRIPTION
Fixed deprecation warning in Rails 3.2.7

Closes #44
