### PR TITLE
support accepts_nested_attributes_for multi-destroy

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -75,6 +75,7 @@ module ActiveRecord
 
             #{scope_condition_method}
 
+            before_destroy :reload_position
             after_destroy :decrement_positions_on_lower_items
             before_create :add_to_list_#{configuration[:add_new_at]}
             after_update :update_positions
@@ -324,6 +325,10 @@ module ActiveRecord
             new_position = send(position_column).to_i
             return unless acts_as_list_class.unscoped.where("#{position_column} = #{new_position}").count > 1
             shuffle_positions_on_intermediate_items old_position, new_position, id
+          end
+
+          def reload_position
+            self.reload
           end
       end
     end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -349,6 +349,51 @@ class DefaultScopedWhereTest < ActsAsListTestCase
 
 end
 
+class MultiDestroyTest < ActsAsListTestCase
+
+  def setup
+    setup_db
+  end
+
+  # example:
+  #
+  #   class TodoList < ActiveRecord::Base
+  #     has_many :todo_items, :order => "position"
+  #     accepts_nested_attributes_for :todo_items, :allow_destroy => true
+  #   end
+  #
+  #   class TodoItem < ActiveRecord::Base
+  #     belongs_to :todo_list
+  #     acts_as_list :scope => :todo_list
+  #   end
+  #
+  # Assume that there are three items.
+  # The user mark two items as deleted, click save button, form will be post:
+  #
+  # todo_list.todo_items_attributes = [
+  #   {id: 1, _destroy: true},
+  #   {id: 2, _destroy: true}
+  # ]
+  #
+  # Save toto_list, the position of item #3 should eql 1.
+  #
+  def test_destroy
+    new1 = DefaultScopedMixin.create
+    assert_equal 1, new1.pos
+
+    new2 = DefaultScopedMixin.create
+    assert_equal 2, new2.pos
+
+    new3 = DefaultScopedMixin.create
+    assert_equal 3, new3.pos
+
+    new1.destroy
+    new2.destroy
+    new3.reload
+    assert_equal 1, new3.pos
+  end
+end
+
 #class TopAdditionMixin < Mixin
 
 class TopAdditionTest < ActsAsListTestCase


### PR DESCRIPTION
Hi, there is a bug when we use accepts_nested_attributes_for multi-destroy.
And here is the patch to solve this problem with simple test.
