### PR TITLE
Fixed issue with update_positions that wasn't taking 'scope_condition' into account

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -322,7 +322,7 @@ module ActiveRecord
           def update_positions
             old_position = send("#{position_column}_was").to_i
             new_position = send(position_column).to_i
-            return unless acts_as_list_class.unscoped.where("#{position_column} = #{new_position}").count > 1
+            return unless acts_as_list_class.unscoped.where("#{scope_condition} AND #{position_column} = #{new_position}").count > 1
             shuffle_positions_on_intermediate_items old_position, new_position, id
           end
       end

--- a/test/shared_array_scope_list.rb
+++ b/test/shared_array_scope_list.rb
@@ -2,6 +2,7 @@ module Shared
   module ArrayScopeList
     def setup
       (1..4).each { |counter| ArrayScopeListMixin.create! :pos => counter, :parent_id => 5, :parent_type => 'ParentClass' }
+      (1..4).each { |counter| ArrayScopeListMixin.create! :pos => counter, :parent_id => 6, :parent_type => 'ParentClass' }
     end
 
     def test_reordering
@@ -24,6 +25,10 @@ module Shared
 
       ArrayScopeListMixin.find(4).move_to_top
       assert_equal [4, 1, 3, 2], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+      
+      ArrayScopeListMixin.find(4).insert_at(4)
+      assert_equal [1, 3, 2, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:id)
+      assert_equal [1, 2, 3, 4], ArrayScopeListMixin.find(:all, :conditions => "parent_id = 5 AND parent_type = 'ParentClass'", :order => 'pos').map(&:pos)
     end
 
     def test_move_to_bottom_with_next_to_last_item


### PR DESCRIPTION
As soon as you would have more than one list, items positions would be updated twice when calling insert_at. The 'update_positions' callback would check if there are more than one page at the new position, and if there was would update the intermediate items. Problem being that this check didn't take the scope into account.

I've fixed the issue and added a test case.
