### PR TITLE
Changes from update_attributes to assignment

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -137,20 +137,20 @@ module ActiveRecord
         def remove_from_list
           if in_list?
             decrement_positions_on_lower_items
-            update_attributes! position_column => nil
+            set_list_position(nil)
           end
         end
 
         # Increase the position of this item without adjusting the rest of the list.
         def increment_position
           return unless in_list?
-          update_attributes! position_column => self.send(position_column).to_i + 1
+          set_list_position(self.send(position_column).to_i + 1)
         end
 
         # Decrease the position of this item without adjusting the rest of the list.
         def decrement_position
           return unless in_list?
-          update_attributes! position_column => self.send(position_column).to_i - 1
+          set_list_position(self.send(position_column).to_i - 1)
         end
 
         # Return +true+ if this object is the first in the list.
@@ -198,6 +198,12 @@ module ActiveRecord
           default_position == send(position_column)
         end
 
+        # Sets the new position and saves it
+        def set_list_position(new_position)
+          send("#{position_column}=", new_position)
+          save!
+        end
+
         private
           def add_to_list_top
             increment_positions_on_all_items
@@ -231,12 +237,12 @@ module ActiveRecord
 
           # Forces item to assume the bottom position in the list.
           def assume_bottom_position
-            update_attributes!(position_column => bottom_position_in_list(self).to_i + 1)
+            set_list_position(bottom_position_in_list(self).to_i + 1)
           end
 
           # Forces item to assume the top position in the list.
           def assume_top_position
-            update_attributes!(position_column => acts_as_list_top)
+            set_list_position(acts_as_list_top)
           end
 
           # This has the effect of moving all the higher items up one.
@@ -308,14 +314,14 @@ module ActiveRecord
             else
               increment_positions_on_lower_items(position)
             end
-            self.update_attributes!(position_column => position)
+            set_list_position(position)
           end
 
           # used by insert_at_position instead of remove_from_list, as postgresql raises error if position_column has non-null constraint
           def store_at_0
             if in_list?
               old_position = send(position_column).to_i
-              update_attributes!(position_column => 0)
+              set_list_position(0)
               decrement_positions_on_lower_items(old_position)
             end
           end

--- a/test/shared_list.rb
+++ b/test/shared_list.rb
@@ -204,14 +204,14 @@ module Shared
     def test_before_create_callback_adds_to_given_position
       assert_equal [1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
 
-      new = ListMixin.create(:pos => 1, :parent_id => 5)
+      new = ListMixin.create(:parent_id => 5) {|list_item| list_item.pos = 1 }
       assert_equal 1, new.pos
       assert new.first?
       assert !new.last?
 
       assert_equal [5, 1, 2, 3, 4], ListMixin.find(:all, :conditions => 'parent_id = 5', :order => 'pos').map(&:id)
 
-      new = ListMixin.create(:pos => 3, :parent_id => 5)
+      new = ListMixin.create(:parent_id => 5) {|list_item| list_item.pos = 3 }
       assert_equal 3, new.pos
       assert !new.first?
       assert !new.last?

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -1,7 +1,7 @@
 module Shared
   module ListSub
     def setup
-      (1..4).each { |i| ((i % 2 == 1) ? ListMixinSub1 : ListMixinSub2).create! :pos => i, :parent_id => 5000 }
+      (1..4).each { |i| ((i % 2 == 1) ? ListMixinSub1 : ListMixinSub2).create!(:parent_id => 5000) {|list_item| list_item.pos = i } }
     end
 
     def test_reordering

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -40,6 +40,8 @@ end
 
 class ListMixin < Mixin
   acts_as_list :column => "pos", :scope => :parent
+
+  attr_accessible :parent_id
 end
 
 class ListMixinSub1 < ListMixin
@@ -243,13 +245,13 @@ class DefaultScopedTest < ActsAsListTestCase
 
   def test_update_position
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(2).update_attributes!(:pos => 4)
+    DefaultScopedMixin.find(2).set_list_position(4)
     assert_equal [1, 3, 4, 2], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(2).update_attributes!(:pos => 2)
+    DefaultScopedMixin.find(2).set_list_position(2)
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(1).update_attributes!(:pos => 4)
+    DefaultScopedMixin.find(1).set_list_position(4)
     assert_equal [2, 3, 4, 1], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(1).update_attributes!(:pos => 1)
+    DefaultScopedMixin.find(1).set_list_position(1)
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
   end
 
@@ -337,7 +339,7 @@ class DefaultScopedWhereTest < ActsAsListTestCase
 
   def test_update_position
     assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(2).update_attributes!(:pos => 4)
+    DefaultScopedWhereMixin.where(:active => false).find(2).set_list_position(4)
     assert_equal [1, 3, 4, 2], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
     DefaultScopedWhereMixin.where(:active => false).find(2).update_attributes!(:pos => 2)
     assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)


### PR DESCRIPTION
Marks position column as not attr_accessible (like it is in many apps) 
and sets the column by directly setting the attribute.

Fixes issue https://github.com/swanandp/acts_as_list/issues/50

I don't know if there was a reason for using update_attributes!, I couldn't 
find any. This patch adds `set_list_position` public method. It could also 
be private but there are few tests that used update_attributes! which I 
converted to use the new `set_list_position` method.

This way of fixing the problem doesn't make acts_as_list dependent of 
`attr_accessible` like https://github.com/swanandp/acts_as_list/pull/51 
which is nice considering strong_parameters seems to be the future.
