### PR TITLE
attr-accessible can be damaging, is not always necessary.

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -144,20 +144,20 @@ module ActiveRecord
         def remove_from_list
           if in_list?
             decrement_positions_on_lower_items
-            update_attribute(position_column, nil)
+            set_list_position(nil)
           end
         end
 
         # Increase the position of this item without adjusting the rest of the list.
         def increment_position
           return unless in_list?
-          update_attribute(position_column, self.send(position_column).to_i + 1)
+          set_list_position(self.send(position_column).to_i + 1)
         end
 
         # Decrease the position of this item without adjusting the rest of the list.
         def decrement_position
           return unless in_list?
-          update_attribute(position_column, self.send(position_column).to_i - 1)
+          set_list_position(self.send(position_column).to_i - 1)
         end
 
         # Return +true+ if this object is the first in the list.
@@ -205,6 +205,12 @@ module ActiveRecord
           default_position == send(position_column)
         end
 
+        # Sets the new position and saves it
+        def set_list_position(new_position)
+          send("#{position_column}=", new_position)
+          save!
+        end
+
         private
           def add_to_list_top
             increment_positions_on_all_items
@@ -238,12 +244,12 @@ module ActiveRecord
 
           # Forces item to assume the bottom position in the list.
           def assume_bottom_position
-            update_attribute(position_column, bottom_position_in_list(self).to_i + 1)
+            set_list_position(bottom_position_in_list(self).to_i + 1)
           end
 
           # Forces item to assume the top position in the list.
           def assume_top_position
-            update_attribute(position_column, acts_as_list_top)
+            set_list_position(acts_as_list_top)
           end
 
           # This has the effect of moving all the higher items up one.
@@ -315,14 +321,14 @@ module ActiveRecord
             else
               increment_positions_on_lower_items(position)
             end
-            self.update_attribute(position_column, position)
+            set_list_position(position)
           end
 
           # used by insert_at_position instead of remove_from_list, as postgresql raises error if position_column has non-null constraint
           def store_at_0
             if in_list?
               old_position = send(position_column).to_i
-              update_attribute(position_column,  0)
+              set_list_position(0)
               decrement_positions_on_lower_items(old_position)
             end
           end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -262,13 +262,13 @@ class DefaultScopedTest < ActsAsListTestCase
 
   def test_update_position
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(2).update_attribute(:pos, 4)
+    DefaultScopedMixin.find(2).set_list_position(4)
     assert_equal [1, 3, 4, 2], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(2).update_attribute(:pos,  2)
+    DefaultScopedMixin.find(2).set_list_position(2)
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(1).update_attribute(:pos,  4)
+    DefaultScopedMixin.find(1).set_list_position(4)
     assert_equal [2, 3, 4, 1], DefaultScopedMixin.find(:all).map(&:id)
-    DefaultScopedMixin.find(1).update_attribute(:pos,  1)
+    DefaultScopedMixin.find(1).set_list_position(1)
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.find(:all).map(&:id)
   end
 
@@ -356,13 +356,13 @@ class DefaultScopedWhereTest < ActsAsListTestCase
 
   def test_update_position
     assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(2).update_attribute(:pos, 4)
+    DefaultScopedWhereMixin.where(:active => false).find(2).set_list_position(4)
     assert_equal [1, 3, 4, 2], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(2).update_attribute(:pos, 2)
+    DefaultScopedWhereMixin.where(:active => false).find(2).set_list_position(2)
     assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(1).update_attribute(:pos, 4)
+    DefaultScopedWhereMixin.where(:active => false).find(1).set_list_position(4)
     assert_equal [2, 3, 4, 1], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
-    DefaultScopedWhereMixin.where(:active => false).find(1).update_attribute(:pos, 1)
+    DefaultScopedWhereMixin.where(:active => false).find(1).set_list_position(1)
     assert_equal [1, 2, 3, 4], DefaultScopedWhereMixin.where(:active => false).find(:all).map(&:id)
   end
 


### PR DESCRIPTION
## Problem:

changes in the attr accessable patch from fabn/attr-accessible-patch
cause a problem on any model which does not already have attr_accessible set
and as a result triggers the "Can't mass-assign protected attributes"
## commit where problem was introduced:

md5: d8c24c026901071b22cac2201a80dd5608d268b0
## Test for problem:

The example included here in a test shows that adding attr_accessible to a model that
does not currently have mass assignment protection enabled, triggers mass_assignment
protection.
## Solution:

I understand that this patch was inteded as a workaround, so as to add 'position'
to the list of available mass assignable attributes of the model,

The problem that required the offending patch is addressable in another manner:
it is not necessary to use 'update_attributes!' to set one known attribute.
instead, i have altered this to use update_attribute, as it doesn't trigger mass_assignment protection.
update_attribute only updates one attribute at a time, therefore avoiding 'mass' assignment.
## 

that being said, it may still be desirable to add 'position' (or it's configured alternate)
to the list of mass_assignable attributes, but only if there is already such a list,

this patch performs a check to see if here is already a whitelist, and if so, adds itself to it.
