### PR TITLE
Add quotes to Id in SQL requests

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -240,7 +240,7 @@ module ActiveRecord
           # Returns the bottom item
           def bottom_item(except = nil)
             conditions = scope_condition
-            conditions = "#{conditions} AND #{self.class.primary_key} != #{except.id}" if except
+            conditions = "#{conditions} AND #{self.class.primary_key} != '#{except.id}'" if except
             acts_as_list_class.unscoped.where(conditions).order("#{acts_as_list_class.table_name}.#{position_column} DESC").first
           end
 


### PR DESCRIPTION
If we use UUID as Id, we need to quote the Id in SQL requests.
