### PR TITLE
`#lower_items` and `#higher_items` returns the items lower and higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ In `acts_as_list`, "higher" means further up the list (a lower `position`), and 
 - `list_item.not_in_list?`
 - `list_item.default_position?`
 - `list_item.higher_item`
+- `list_item.higher_items` will return all the items above `list_item` in the list (ordered by the item closest to `list_item` to the farthest)
 - `list_item.lower_item`
+- `list_item.lower_items` will return all the items below `list_item` in the list (ordered by the item closest to `list_item` to the farthest)
 
 ## Notes
 If the `position` column has a default value, then there is a slight change in behavior, i.e if you have 4 items in the list, and you insert 1, with a default position 0, it would be pushed to the bottom of the list. Please look at the tests for this and some recent pull requests for discussions related to this.

--- a/acts_as_list.gemspec
+++ b/acts_as_list.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
 
 
   # Dependencies (installed via 'bundle install')...
+  s.add_dependency("activerecord", [">= 3.0"])
   s.add_development_dependency("bundler", [">= 1.0.0"])
-  s.add_development_dependency("activerecord", [">= 1.15.4.7794"])
   s.add_development_dependency("rdoc")
   s.add_development_dependency("sqlite3")
 end

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -190,6 +190,16 @@ module ActiveRecord
           )
         end
 
+        # Return the next n higher items in the list
+        # selects all higher items by default
+        def higher_items(limit=nil)
+          limit ||= acts_as_list_list.count
+          acts_as_list_list.
+            where("#{position_column} < ?", send(position_column)).
+            limit(limit).
+            order("#{acts_as_list_class.table_name}.#{position_column} DESC")
+        end
+
         # Return the next lower item in the list.
         def lower_item
           return nil unless in_list?
@@ -197,6 +207,16 @@ module ActiveRecord
             "#{scope_condition} AND #{position_column} > #{(send(position_column).to_i).to_s}",
             :order => "#{acts_as_list_class.table_name}.#{position_column} ASC"
           )
+        end
+
+        # Return the next n lower items in the list
+        # selects all lower items by default
+        def lower_items(limit=nil)
+          limit ||= acts_as_list_list.count
+          acts_as_list_list.
+            where("#{position_column} > ?", send(position_column)).
+            limit(limit).
+            order("#{acts_as_list_class.table_name}.#{position_column} ASC")
         end
 
         # Test if this record is in a list
@@ -223,6 +243,11 @@ module ActiveRecord
         end
 
         private
+          def acts_as_list_list
+            acts_as_list_class.unscoped.
+              where(scope_condition)
+          end
+
           def add_to_list_top
             increment_positions_on_all_items
             self[position_column] = acts_as_list_top

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -43,6 +43,22 @@ module Shared
       assert_nil ListMixin.find(4).lower_item
     end
 
+    def test_next_prev_groups
+      li1 = ListMixin.find(1)
+      li2 = ListMixin.find(2)
+      li3 = ListMixin.find(3)
+      li4 = ListMixin.find(4)
+      assert_equal [li2, li3, li4], li1.lower_items
+      assert_equal [li4], li3.lower_items
+      assert_equal [li2, li3], li1.lower_items(2)
+      assert_empty li4.lower_items
+
+      assert_equal [li2, li1], li3.higher_items
+      assert_equal [li1], li2.higher_items
+      assert_equal [li3, li2], li4.higher_items(2)
+      assert_empty li1.higher_items
+    end
+
     def test_injection
       item = ListMixin.new("parent_id"=>1)
       assert_equal '"mixins"."parent_id" = 1', item.scope_condition


### PR DESCRIPTION
I wanted a way to easily get the items below and above the given list item. This gives that functionality

Notes:
- Adds dependency `activerecord 3.0` and above (this can only be used with that version from now on; I saw that it's somewhat in the roadmap anyway)
