### PR TITLE
Rails 4.0.0.beta1: Utilize attr_accessible if defined for the model

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -86,7 +86,7 @@ module ActiveRecord
             # only add to attr_accessible
             # if the class has some mass_assignment_protection
 
-            if defined?(accessible_attributes) && !accessible_attributes.blank?
+            if respond_to?(:accessible_attributes) && !accessible_attributes.blank?
               attr_accessible :#{configuration[:column]}
             end
 


### PR DESCRIPTION
In Rails 4.0, attr_accessible was moved to a plugin, this will test if accessible_attributes is defined before trying to add it.
