### PR TITLE
Adds `required_ruby_version` to gemspec

### DIFF
--- a/acts_as_list.gemspec
+++ b/acts_as_list.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{A gem allowing a active_record model to act_as_list.}
   s.description = %q{This "acts_as" extension provides the capabilities for sorting and reordering a number of objects in a list. The class that has this specified needs to have a "position" column defined as an integer on the mapped database table.}
   s.rubyforge_project = 'acts_as_list'
-
+  s.required_ruby_version = '>= 1.9.2'
 
   # Load Paths...
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
As `acts_as_list` does not support Ruby 1.8 anymore, the `gemspec` should reflect this.

So if one bundles this gem in ruby 1.8, bundler will raise an error.
