### PR TITLE
Discussion: Add configuration option to allow gaps in list?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ActsAsList
 
+## Why a fork?
+
+This merely allows to disable automatic reordering callbacks on destroy 
+
 ## Description
 
 This `acts_as` extension provides the capabilities for sorting and reordering a number of objects in a list. The class that has this specified needs to have a `position` column defined as an integer on the mapped database table.


### PR DESCRIPTION
I had a very special use case where I wanted to be able to delete items in a list without the lower items automatically updating.

Is this of general interest? If so, I'd want to write tests for this behaviour before this is accepted; I just want to check out whether there's interest in this functionality. (As I imagine it's a pretty special use case.)

Also, it would be nice if someone from the original developers could chime in on whether simply disabling these callbacks is the correct way of implementing this functionality. It seems to work for me so far.
