### PR TITLE
Make acts_as_list more compatible with BINARY column

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -307,7 +307,7 @@ module ActiveRecord
           # Returns the bottom item
           def bottom_item(except = nil)
             conditions = scope_condition
-            conditions = "#{conditions} AND #{self.class.primary_key} != '#{except.id}'" if except
+            conditions = "#{conditions} AND #{self.class.primary_key} != #{self.class.quote_value(except.id)}" if except
             acts_as_list_class.unscoped.in_list.where(conditions).order("#{acts_as_list_class.table_name}.#{position_column} DESC").first
           end
 
@@ -372,7 +372,8 @@ module ActiveRecord
           # Reorders intermediate items to support moving an item from old_position to new_position.
           def shuffle_positions_on_intermediate_items(old_position, new_position, avoid_id = nil)
             return if old_position == new_position
-            avoid_id_condition = avoid_id ? " AND #{self.class.primary_key} != '#{avoid_id}'" : ''
+            avoid_id_condition = avoid_id ? " AND #{self.class.primary_key} != #{self.class.quote_value(avoid_id)}" : ''
+
             if old_position < new_position
               # Decrement position of intermediate items
               #


### PR DESCRIPTION
Use AR::Base.quote_value to quote id value. This makes acts_as_list plays well with non-integer, non-string column, such as UUID which sometimes stored as BINARY column.

```
> 1.to_s
=> "1"
> ActiveRecord::Base.quote_value(1)
=> "1"
> ActiveRecord::Base.quote_value('bacon')
=> "'bacon'"
> UUIDTools::UUID.random_create.to_s
=> "4d661a9a-6797-4ece-9824-6bb603e8254e"
> ActiveRecord::Base.quote_value(UUIDTools::UUID.random_create)
=> "x'f74071abed0e413e915847d088c6835c'"
```

---

Note that I didn't add any new test case to cover this, as that would mean I need to add new dependency to the project. However, I've tested this patch against my project that use https://github.com/jashmenn/activeuuid gem and it works perfectly.
