### PR TITLE
quote_level uses wrong number of params for Rails 4.1

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -307,7 +307,7 @@ module ActiveRecord
           # Returns the bottom item
           def bottom_item(except = nil)
             conditions = scope_condition
-            conditions = "#{conditions} AND #{self.class.primary_key} != #{self.class.quote_value(except.id)}" if except
+            conditions = "#{conditions} AND #{self.class.primary_key} != #{self.class.quote_value(except.id, nil)}" if except
             acts_as_list_class.unscoped.in_list.where(conditions).order("#{acts_as_list_class.table_name}.#{position_column} DESC").first
           end
 
@@ -372,7 +372,7 @@ module ActiveRecord
           # Reorders intermediate items to support moving an item from old_position to new_position.
           def shuffle_positions_on_intermediate_items(old_position, new_position, avoid_id = nil)
             return if old_position == new_position
-            avoid_id_condition = avoid_id ? " AND #{self.class.primary_key} != #{self.class.quote_value(avoid_id)}" : ''
+            avoid_id_condition = avoid_id ? " AND #{self.class.primary_key} != #{self.class.quote_value(avoid_id, nil)}" : ''
 
             if old_position < new_position
               # Decrement position of intermediate items


### PR DESCRIPTION
Rails 4.1, latest version of acts_as_list

Symptoms: any move_\* methods throw the following:

``` code
ArgumentError - wrong number of arguments (1 for 2):
  /Users/stu/projects/br/acts_as_list/acts_as_list/lib/acts_as_list/active_record/acts/list.rb:375:in `shuffle_positions_on_intermediate_items'
  /Users/stu/projects/br/acts_as_list/acts_as_list/lib/acts_as_list/active_record/acts/list.rb:426:in `update_positions'
```

Appears to have broken with this commit

https://github.com/swanandp/acts_as_list/commit/25ae69e2d83b9e68a11f90e3bc7568ad81888df8#diff-e8acc63b1e238f3255c900eed37254b8

quote_value takes 2 arguments, not one.  

Rails 4.1 source:

``` ruby
module ActiveRecord
  module Sanitization
    extend ActiveSupport::Concern

    module ClassMethods
      def quote_value(value, column) #:nodoc:
        connection.quote(value, column)
      end
```

Not sure what you guys want to pass as the second parameter, but in the pull request I pass it as null and my use cases work.  I’m not suggesting that this is the actual fix because I don’t understand the mechanics well enough, but hopefully this will identify the issue and at least share my workaround.
