### PR TITLE
use eval for determing the self.class.name useful when this is used in an abstract class

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -84,7 +84,7 @@ module ActiveRecord
             end
 
             def acts_as_list_class
-              ::#{self.name}
+              @acts_as_list_class ||= eval('::'+self.class.name.to_s)
             end
 
             def position_column


### PR DESCRIPTION
When using acts_as_list in an Inheritance class like this:

``` ruby
class SuperClass < ActiveRecord::Base
  self.abstract_class = true
  acts_as_list
end

class Child < SuperClass
  self.table_name = 'the_table_i_really_want'
end
```

The output of the method acts_as_list_class is set to the name of the parent class (::SuperClass) instead of the child class (::Child). By using eval the correct Class name is returned. I'm using the variable @acts_as_list_class so eval doesn't slow things down.

Maybe there is a better (rails?) way of doing this then eval. But is works.

reference: http://api.rubyonrails.org/classes/ActiveRecord/Inheritance/ClassMethods.html
