### PR TITLE
Fix travis builds for rbx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - jruby-19mode
-  - rbx
+  - rbx-2
 gemfile:
  - gemfiles/rails3/Gemfile
  - gemfiles/rails4/Gemfile


### PR DESCRIPTION
Currently, the Travis build is failing due to a wrong specified version of
rbx. According to the docs, Travis currently expects rbx-2 here.

> When using Rubinius, there's currently an issue with selecting the
> correct version in RVM in our build environment, but only when
> specifying `rbx` as your version. As a workaround, specify `rbx-2` instead.

-- from http://docs.travis-ci.com/user/languages/ruby/
