### PR TITLE
Cast column default value to int before comparing with position column

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -274,7 +274,7 @@ module ActiveRecord
         end
 
         def default_position?
-          default_position == send(position_column)
+          default_position && default_position.to_i == send(position_column)
         end
 
         # Sets the new position and saves it


### PR DESCRIPTION
This fixes an issue resulting from Model.columns_hash['position'].default being returned as a String object. Since `send(position_column)` returns the default value after casting, the comparison in `default_position?` fails.

Seen while running Rails 4.2.0beta1 with a Postgres database.

```
irb(main):003:0> pp LineItem.columns_hash['position'].default
"0"
```
