### PR TITLE
Simpler method to find the subclass name

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -84,7 +84,7 @@ module ActiveRecord
             end
 
             def acts_as_list_class
-              @acts_as_list_class ||= eval('::'+self.class.name.to_s)
+              self.class
             end
 
             def position_column

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -118,5 +118,10 @@ module Shared
       assert_equal 1, ListMixin.where(id: 3).first.pos
       assert_equal 2, ListMixin.where(id: 4).first.pos
     end
+
+    def test_acts_as_list_class
+      assert_equal TheSubClass1, TheSubClass1.new.acts_as_list_class
+      assert_equal TheSubClass2, TheSubClass2.new.acts_as_list_class
+    end
   end
 end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -92,6 +92,19 @@ class NoAdditionMixin < Mixin
   acts_as_list column: "pos", add_new_at: nil, scope: :parent_id
 end
 
+class TheBaseClass < ActiveRecord::Base
+  self.abstract_class = true
+  acts_as_list column: "pos", scope: :parent
+end
+
+class TheSubClass1 < TheBaseClass
+  self.table_name = 'mixins'
+end
+
+class TheSubClass2 < TheBaseClass
+  self.table_name = 'mixins'
+end
+
 class ActsAsListTestCase < Minitest::Test
   # No default test required as this class is abstract.
   # Need for test/unit.


### PR DESCRIPTION
In swanandp#123 the method used to get the class name seems quite convoluted. I've done some testing and found calling self.class works fine in this scenario. I've added some tests for this too.

Let me know if I've missed something.

Memoising also doesn't seem necessary as the test suite runs just as fast without it.
