### PR TITLE
Bump minimum required version of activerecord

### DIFF
--- a/acts_as_list.gemspec
+++ b/acts_as_list.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
 
 
   # Dependencies (installed via 'bundle install')...
-  s.add_dependency("activerecord", [">= 3.0"])
+  s.add_dependency("activerecord", [">= 3.2"])
   s.add_development_dependency("bundler", [">= 1.0.0"])
 end

--- a/gemfiles/rails3/Gemfile
+++ b/gemfiles/rails3/Gemfile
@@ -9,7 +9,7 @@ platforms :rbx do
   gem 'rubysl-test-unit'
 end
 
-gem 'activerecord', '>= 3.0', '< 4'
+gem 'activerecord', '>= 3.2', '< 4'
 
 # Specify your gem's dependencies in acts_as_list.gemspec
 gemspec :path => File.join('..', '..')


### PR DESCRIPTION
It seems not working with activerecord 3.0 or 3.1.

```
% bundle show | grep activerecord
  * activerecord (3.1.12)
% bundle exec rake
Run options: --seed 62813

# Running:

EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE

Finished in 0.094504s, 1068.7419 runs/s, 0.0000 assertions/s.

  1) Error:
ZeroBasedTest#test_reordering:
NoMethodError: undefined method `schema_cache' for #<ActiveRecord::ConnectionAdapters::SQLite3Adapter:0x007f9eeee1f070>
    /home/eagletmt/.ghq/github.com/swanandp/acts_as_list/test/test_list.rb:18:in `setup_db'
    /home/eagletmt/.ghq/github.com/swanandp/acts_as_list/test/test_list.rb:109:in `setup'

(snip)
```
