### PR TITLE
Keep position when changing scope for add_new_at top

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -291,7 +291,7 @@ module ActiveRecord
           end
 
           def add_to_list_top
-            if not_in_list? || default_position?
+            if not_in_list? || scope_changed? && !@position_changed || default_position?
               increment_positions_on_all_items
               self[position_column] = acts_as_list_top
             else

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -291,8 +291,12 @@ module ActiveRecord
           end
 
           def add_to_list_top
-            increment_positions_on_all_items
-            self[position_column] = acts_as_list_top
+            if not_in_list? || default_position?
+              increment_positions_on_all_items
+              self[position_column] = acts_as_list_top
+            else
+              increment_positions_on_lower_items(self[position_column])
+            end
           end
 
           def add_to_list_bottom

--- a/test/shared_top_addition.rb
+++ b/test/shared_top_addition.rb
@@ -1,7 +1,7 @@
 module Shared
   module TopAddition
     def setup
-      (1..4).each { |counter| TopAdditionMixin.create! pos: counter, parent_id: 5 }
+      (1..4).each { |counter| TopAdditionMixin.create! parent_id: 5 }
     end
 
     def test_reordering


### PR DESCRIPTION
This makes the behavior consistent with add_new_at: :bottom and fixes #138.