### PR TITLE
Fix regression with using acts_as_list on base classes

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -84,7 +84,7 @@ module ActiveRecord
             end
 
             def acts_as_list_class
-              self.class
+              ::#{self.name}
             end
 
             def position_column

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -120,8 +120,8 @@ module Shared
     end
 
     def test_acts_as_list_class
-      assert_equal TheSubClass1, TheSubClass1.new.acts_as_list_class
-      assert_equal TheSubClass2, TheSubClass2.new.acts_as_list_class
+      assert_equal TheBaseClass, TheBaseSubclass.new.acts_as_list_class
+      assert_equal TheAbstractSubclass, TheAbstractSubclass.new.acts_as_list_class
     end
   end
 end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -109,17 +109,21 @@ class NoAdditionMixin < Mixin
   acts_as_list column: "pos", add_new_at: nil, scope: :parent_id
 end
 
-class TheBaseClass < ActiveRecord::Base
+class TheAbstractClass < ActiveRecord::Base
   self.abstract_class = true
+  self.table_name = 'mixins'
+end
+
+class TheAbstractSubclass < TheAbstractClass
   acts_as_list column: "pos", scope: :parent
 end
 
-class TheSubClass1 < TheBaseClass
+class TheBaseClass < ActiveRecord::Base
   self.table_name = 'mixins'
+  acts_as_list column: "pos", scope: :parent
 end
 
-class TheSubClass2 < TheBaseClass
-  self.table_name = 'mixins'
+class TheBaseSubclass < TheBaseClass
 end
 
 class ActsAsListTestCase < Minitest::Test


### PR DESCRIPTION
https://github.com/swanandp/acts_as_list/pull/123 introduced a regression, since  `acts_as_list_class` now returns the subclass, not the superclass. My use-case is as follows:

```ruby
class Segment < AR::Base
  acts_as_list
end

class Video < Segment; end
class Quiz < Segment; end
class Exam < Segment; end
```

The application is an online course, which is composed of videos, quizzes, and exams. acts_as_list keeps these in order. However, after https://github.com/swanandp/acts_as_list/pull/123, `lower_item` will return the next item of the _same subclass_, skipping over other segments of other subclasses, which is not at all desired.

If one desires this behavior, declaring `acts_as_list` on the subclasses separately makes sense. This PR reverts the regression, and includes tests for both use-cases.