### PR TITLE
Only swap changed attributes which are persistable, i.e. are DB columns.

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -461,7 +461,7 @@ module ActiveRecord
 
           # Temporarily swap changes attributes with current attributes
           def swap_changed_attributes
-            @changed_attributes.select do |k, _|
+            @changed_attributes.each do |k, _|
               if self.class.column_names.include? k
                 @changed_attributes[k], self[k] = self[k], @changed_attributes[k]
               end

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -461,8 +461,11 @@ module ActiveRecord
 
           # Temporarily swap changes attributes with current attributes
           def swap_changed_attributes
-            @changed_attributes.each { |k, _| @changed_attributes[k], self[k] =
-              self[k], @changed_attributes[k] }
+            @changed_attributes.select do |k, _|
+              if self.class.column_names.include? k
+                @changed_attributes[k], self[k] = self[k], @changed_attributes[k]
+              end
+            end
           end
 
           def check_scope


### PR DESCRIPTION
This patches an issue where `acts_as_list would` try to swap virtual attributes, resulting in a crashing ActiveRecord write_attribute method.

I observed this issue in combination with `acts_as_taggable`, I have attached a [partial stack trace here](https://gist.github.com/ludwigschubert/a26929baa2bd9e660c37).
My solution built on a similar fix for the `paper_trail` gem, from [this PR](https://github.com/airblade/paper_trail/pull/236).