### PR TITLE
Permit polymorphic association as scope

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -38,7 +38,13 @@ module ActiveRecord
           configuration = { column: "position", scope: "1 = 1", top_of_list: 1, add_new_at: :bottom}
           configuration.update(options) if options.is_a?(Hash)
 
-          configuration[:scope] = "#{configuration[:scope]}_id".intern if configuration[:scope].is_a?(Symbol) && configuration[:scope].to_s !~ /_id$/
+          if configuration[:scope].is_a?(Symbol) && configuration[:scope].to_s !~ /_id$/
+            if reflect_on_association(configuration).try(:options).try(:[], :polymorphic) == true
+              configuration[:scope] = ["#{configuration[:scope]}_id".intern, "#{configuration[:scope]}_type".intern]
+            else
+              configuration[:scope] = "#{configuration[:scope]}_id".intern
+            end
+          end
 
           if configuration[:scope].is_a?(Symbol)
             scope_methods = %(


### PR DESCRIPTION
Currently acts_as_list behaves un-intuitively with polymorphic associations, leading to confusing and hard-to-trace logical errors when user attempts to use polymorphic association as scope in intuitive manner, like this:  

    class Address  
      belongs_to :addressable, polymorphic: true
      acts_as_list scope: :addressable
    end    

A workaround was described here http://jakeboxer.com/blog/2011/10/09/using-acts-as-list-in-a-polymorphic-scope/, and recommends using a construction like:  

    class Address  
      belongs_to :addressable, polymorphic: true
      acts_as_list scope: [:addressable_id, :addressable_type]
    end

This commit allows the user to use the first, more intuitive, construction to avoid subtle logic errors that show up later.  

Please let me know if I'm contributing wrongly.  Thanks!  - Luke