### PR TITLE
Touch when reordering

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -122,11 +122,15 @@ module ActiveRecord
             end
 
             def self.update_all_with_touch(updates)
-              attrs = new.send(:timestamp_attributes_for_update_in_model)
+              record = new
+              attrs = record.send(:timestamp_attributes_for_update_in_model)
+              now = record.send(:current_time_from_proper_timezone)
+
               query = attrs.map { |attr| "\#{attr} = :now" }
               query.push updates
               query = query.join(", ")
-              update_all([query, now: Time.now.utc])
+
+              update_all([query, now: now])
             end
           EOV
 

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -479,22 +479,19 @@ module ActiveRecord
           end
 
           def decrement_all_with_touch(scope)
-            touch_all scope
-            scope.update_all "#{quoted_position_column} = (#{quoted_position_column} - 1)"
+            update_all_with_touch scope, "#{quoted_position_column} = (#{quoted_position_column} - 1)"
           end
 
           def increment_all_with_touch(scope)
-            touch_all scope
-            scope.update_all "#{quoted_position_column} = (#{quoted_position_column} + 1)"
+            update_all_with_touch scope, "#{quoted_position_column} = (#{quoted_position_column} + 1)"
           end
 
-          def touch_all(scope)
+          def update_all_with_touch(scope, updates)
             attrs = timestamp_attributes_for_update_in_model
-            return if attrs.empty?
-            query = attrs.inject({}) do |hash, attr|
-              hash.merge attr => Time.now.utc
-            end
-            scope.update_all(query)
+            query = attrs.map { |attr| "#{attr} = :now" }
+            query.push updates
+            query = query.join(", ")
+            scope.update_all([query, now: Time.now.utc])
           end
       end
     end

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -113,11 +113,11 @@ module ActiveRecord
 
             scope :in_list, lambda { where(%q{#{quoted_table_name}.#{quoted_position_column} IS NOT NULL}) }
 
-            def self.decrement_all_with_touch
+            def self.decrement_all
               update_all_with_touch %q(#{quoted_position_column} = (#{quoted_table_name}.#{quoted_position_column} - 1))
             end
 
-            def self.increment_all_with_touch
+            def self.increment_all
               update_all_with_touch %q(#{quoted_position_column} = (#{quoted_table_name}.#{quoted_position_column} + 1))
             end
 
@@ -367,32 +367,32 @@ module ActiveRecord
 
           # This has the effect of moving all the higher items up one.
           def decrement_positions_on_higher_items(position)
-            acts_as_list_list.where("#{quoted_position_column} <= #{position}").decrement_all_with_touch
+            acts_as_list_list.where("#{quoted_position_column} <= #{position}").decrement_all
           end
 
           # This has the effect of moving all the lower items up one.
           def decrement_positions_on_lower_items(position=nil)
             return unless in_list?
             position ||= send(position_column).to_i
-            acts_as_list_list.where("#{quoted_position_column} > #{position}").decrement_all_with_touch
+            acts_as_list_list.where("#{quoted_position_column} > #{position}").decrement_all
           end
 
           # This has the effect of moving all the higher items down one.
           def increment_positions_on_higher_items
             return unless in_list?
-            acts_as_list_list.where("#{quoted_position_column} < #{send(position_column).to_i}").increment_all_with_touch
+            acts_as_list_list.where("#{quoted_position_column} < #{send(position_column).to_i}").increment_all
           end
 
           # This has the effect of moving all the lower items down one.
           def increment_positions_on_lower_items(position, avoid_id = nil)
             avoid_id_condition = avoid_id ? " AND #{self.class.primary_key} != #{self.class.connection.quote(avoid_id)}" : ''
 
-            acts_as_list_list.where("#{quoted_position_column} >= #{position}#{avoid_id_condition}").increment_all_with_touch
+            acts_as_list_list.where("#{quoted_position_column} >= #{position}#{avoid_id_condition}").increment_all
           end
 
           # Increments position (<tt>position_column</tt>) of all items in the list.
           def increment_positions_on_all_items
-            acts_as_list_list.increment_all_with_touch
+            acts_as_list_list.increment_all
           end
 
           # Reorders intermediate items to support moving an item from old_position to new_position.
@@ -409,7 +409,7 @@ module ActiveRecord
                 "#{quoted_position_column} > #{old_position}"
               ).where(
                 "#{quoted_position_column} <= #{new_position}#{avoid_id_condition}"
-              ).decrement_all_with_touch
+              ).decrement_all
             else
               # Increment position of intermediate items
               #
@@ -419,7 +419,7 @@ module ActiveRecord
                 "#{quoted_position_column} >= #{new_position}"
               ).where(
                 "#{quoted_position_column} < #{old_position}#{avoid_id_condition}"
-              ).increment_all_with_touch
+              ).increment_all
             end
           end
 

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -114,11 +114,11 @@ module ActiveRecord
             scope :in_list, lambda { where(%q{#{quoted_table_name}.#{quoted_position_column} IS NOT NULL}) }
 
             def self.decrement_all_with_touch
-              update_all_with_touch %q(#{quoted_position_column} = (#{quoted_position_column} - 1))
+              update_all_with_touch %q(#{quoted_position_column} = (#{quoted_table_name}.#{quoted_position_column} - 1))
             end
 
             def self.increment_all_with_touch
-              update_all_with_touch %q(#{quoted_position_column} = (#{quoted_position_column} + 1))
+              update_all_with_touch %q(#{quoted_position_column} = (#{quoted_table_name}.#{quoted_position_column} + 1))
             end
 
             def self.update_all_with_touch(updates)
@@ -126,7 +126,7 @@ module ActiveRecord
               attrs = record.send(:timestamp_attributes_for_update_in_model)
               now = record.send(:current_time_from_proper_timezone)
 
-              query = attrs.map { |attr| "\#{attr} = :now" }
+              query = attrs.map { |attr| %(\#{connection.quote_column_name(attr)} = :now) }
               query.push updates
               query = query.join(", ")
 

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -632,50 +632,62 @@ end
 class TouchTest < ActsAsListTestCase
   def setup
     setup_db
-    4.times { ListMixin.create! updated_at: 1.day.ago }
+    4.times { ListMixin.create! updated_at: yesterday }
+  end
+
+  def now
+    Time.now.utc
+  end
+
+  def yesterday
+    1.day.ago
+  end
+
+  def updated_ats
+    ListMixin.pluck(:updated_at)
   end
 
   def test_moving_item_lower_touches_self_and_lower_item
     ListMixin.first.move_lower
-    ListMixin.pluck(:updated_at)[0..1].each do |updated_at|
-      assert_in_delta updated_at, Time.now.utc, 1.second
+    updated_ats[0..1].each do |updated_at|
+      assert_in_delta updated_at, now, 1.second
     end
-    ListMixin.pluck(:updated_at)[2..3].each do |updated_at|
-      assert_in_delta updated_at, 1.day.ago, 1.second
+    updated_ats[2..3].each do |updated_at|
+      assert_in_delta updated_at, yesterday, 1.second
     end
   end
 
   def test_moving_item_higher_touches_self_and_higher_item
     ListMixin.all.second.move_higher
-    ListMixin.pluck(:updated_at)[0..1].each do |updated_at|
-      assert_in_delta updated_at, Time.now.utc, 1.second
+    updated_ats[0..1].each do |updated_at|
+      assert_in_delta updated_at, now, 1.second
     end
-    ListMixin.pluck(:updated_at)[2..3].each do |updated_at|
-      assert_in_delta updated_at, 1.day.ago, 1.second
+    updated_ats[2..3].each do |updated_at|
+      assert_in_delta updated_at, yesterday, 1.second
     end
   end
 
   def test_moving_item_to_bottom_touches_all_other_items
     ListMixin.first.move_to_bottom
-    ListMixin.pluck(:updated_at).each do |updated_at|
-      assert_in_delta updated_at, Time.now.utc, 1.second
+    updated_ats.each do |updated_at|
+      assert_in_delta updated_at, now, 1.second
     end
   end
 
   def test_moving_item_to_top_touches_all_other_items
     ListMixin.last.move_to_top
-    ListMixin.pluck(:updated_at).each do |updated_at|
-      assert_in_delta updated_at, Time.now.utc, 1.second
+    updated_ats.each do |updated_at|
+      assert_in_delta updated_at, now, 1.second
     end
   end
 
   def test_removing_item_touches_all_lower_items
     ListMixin.all.third.remove_from_list
-    ListMixin.pluck(:updated_at)[0..1].each do |updated_at|
-      assert_in_delta updated_at, 1.day.ago, 1.second
+    updated_ats[0..1].each do |updated_at|
+      assert_in_delta updated_at, yesterday, 1.second
     end
-    ListMixin.pluck(:updated_at)[2..2].each do |updated_at|
-      assert_in_delta updated_at, Time.now.utc, 1.second
+    updated_ats[2..2].each do |updated_at|
+      assert_in_delta updated_at, now, 1.second
     end
   end
 end


### PR DESCRIPTION
Ran into an issue today with `acts_as_list` and fragment caching. I have a list of items that are expensive to render, so they are each being fragment cached. These items also can be reordered by drag-and-drop. However, only the item that was being dragged got its `updated_at` timestamp touched, so only that item's fragment cache got busted. The remaining items had stale caches with stale position information, even though this information had been updated in the db. Thus, this PR.

What do you think?