### PR TITLE
Escapes table name to fix Mysql2 errors

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -121,7 +121,7 @@ module ActiveRecord
 
             after_commit 'remove_instance_variable(:@scope_changed) if defined?(@scope_changed)'
 
-            scope :in_list, lambda { where("#{table_name}.#{configuration[:column]} IS NOT NULL") }
+            scope :in_list, lambda { where("`#{table_name}`.#{configuration[:column]} IS NOT NULL") }
           EOV
 
           if configuration[:add_new_at].present?
@@ -235,7 +235,7 @@ module ActiveRecord
             where("#{position_column} < ?", position_value).
             where("#{position_column} >= ?", position_value - limit).
             limit(limit).
-            order("#{acts_as_list_class.table_name}.#{position_column} ASC")
+            order("`#{acts_as_list_class.table_name}`.#{position_column} ASC")
         end
 
         # Return the next lower item in the list.
@@ -253,7 +253,7 @@ module ActiveRecord
             where("#{position_column} > ?", position_value).
             where("#{position_column} <= ?", position_value + limit).
             limit(limit).
-            order("#{acts_as_list_class.table_name}.#{position_column} ASC")
+            order("`#{acts_as_list_class.table_name}`.#{position_column} ASC")
         end
 
         # Test if this record is in a list
@@ -328,7 +328,7 @@ module ActiveRecord
             acts_as_list_list.in_list.where(
               conditions
             ).order(
-              "#{acts_as_list_class.table_name}.#{position_column} DESC"
+              "`#{acts_as_list_class.table_name}`.#{position_column} DESC"
             ).first
           end
 


### PR DESCRIPTION
I'm working on a project where I have inherited weird table names (porting the app from another language/framework to Ruby on Rails).
Currently some tables are named like so `table-name` which cause the following error:

`Mysql2::Error: Unknown column 'table' in 'where clause': SELECT  `table-name`.* FROM `table-name` WHERE (table-name.position IS NOT NULL) AND `table-name`.`snapshot_query_id` = 1  ORDER BY table-name.position DESC LIMIT 1`

Escaping the table name with \` \` helps avoid this problem.