### PR TITLE
Changelog generator, closes #68

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gemspec
 
 gem "rake"
 gem "appraisal"
+# Used to automatically generate changelog file
+gem "github_changelog_generator"
 
 group :test do
 	gem "minitest"

--- a/Rakefile
+++ b/Rakefile
@@ -32,3 +32,11 @@ rescue LoadError
 rescue StandardError
   puts "RDocTask is not supported on this platform."
 end
+
+# See https://github.com/skywinder/github-changelog-generator#rake-task for details
+# and github_changelog_generator --help for available options
+require 'github_changelog_generator/task'
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.project = 'acts_as_list'
+  config.user = 'swanandp'
+end


### PR DESCRIPTION
You can use this [awesome gem](https://github.com/skywinder/github-changelog-generator) to maintain a properly formatted changelog file with links to issues, PR and full diff for each version.

I generated an example changelog (date and version info still missing because of missing tags in your repo) here: https://gist.github.com/fabn/32f51f88a6f29c718dd5

I used the [version history](https://github.com/swanandp/acts_as_list/commits/5e3cedabde76fcc27098af6d660618f542e5a2e3/lib/acts_as_list/version.rb) to properly tag all releases after 0.1.3 in my fork, so you can grab them from my repo if you wish.

If you merge this PR you can generate a full and up to date changelog with 

```
rake changelog
```

Finally if you want to manage which issues are listed in changelog you should use github labels to exclude issues from generated file. For instance you can skip issues like #170 by labeling them as `invalid`.

If you want I can help you to tag issues, but in order to do that you should add me as collaborator.

Please merge this, this project deserves a changelog.