### PR TITLE
Fix ambiguous column error when joining some relations

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -255,8 +255,8 @@ module ActiveRecord
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
-            where("#{position_column} < ?", position_value).
-            where("#{position_column} >= ?", position_value - limit).
+            where("#{acts_as_list_class.table_name}.#{position_column} < ?", position_value).
+            where("#{acts_as_list_class.table_name}.#{position_column} >= ?", position_value - limit).
             limit(limit).
             order("#{quoted_table_name}.#{quoted_position_column} ASC")
         end
@@ -273,8 +273,8 @@ module ActiveRecord
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
-            where("#{position_column} > ?", position_value).
-            where("#{position_column} <= ?", position_value + limit).
+            where("#{acts_as_list_class.table_name}.#{position_column} > ?", position_value).
+            where("#{acts_as_list_class.table_name}.#{position_column} <= ?", position_value + limit).
             limit(limit).
             order("#{quoted_table_name}.#{quoted_position_column} ASC")
         end

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -255,8 +255,8 @@ module ActiveRecord
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
-            where("#{quoted_table_name}.#{position_column} < ?", position_value).
-            where("#{quoted_table_name}.#{position_column} >= ?", position_value - limit).
+            where("#{quoted_table_name}.#{quoted_position_column} < ?", position_value).
+            where("#{quoted_table_name}.#{quoted_position_column} >= ?", position_value - limit).
             limit(limit).
             order("#{quoted_table_name}.#{quoted_position_column} ASC")
         end
@@ -273,8 +273,8 @@ module ActiveRecord
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
-            where("#{quoted_table_name}.#{position_column} > ?", position_value).
-            where("#{quoted_table_name}.#{position_column} <= ?", position_value + limit).
+            where("#{quoted_table_name}.#{quoted_position_column} > ?", position_value).
+            where("#{quoted_table_name}.#{quoted_position_column} <= ?", position_value + limit).
             limit(limit).
             order("#{quoted_table_name}.#{quoted_position_column} ASC")
         end

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -255,8 +255,8 @@ module ActiveRecord
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
-            where("#{acts_as_list_class.table_name}.#{position_column} < ?", position_value).
-            where("#{acts_as_list_class.table_name}.#{position_column} >= ?", position_value - limit).
+            where("#{quoted_table_name}.#{position_column} < ?", position_value).
+            where("#{quoted_table_name}.#{position_column} >= ?", position_value - limit).
             limit(limit).
             order("#{quoted_table_name}.#{quoted_position_column} ASC")
         end
@@ -273,8 +273,8 @@ module ActiveRecord
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
-            where("#{acts_as_list_class.table_name}.#{position_column} > ?", position_value).
-            where("#{acts_as_list_class.table_name}.#{position_column} <= ?", position_value + limit).
+            where("#{quoted_table_name}.#{position_column} > ?", position_value).
+            where("#{quoted_table_name}.#{position_column} <= ?", position_value + limit).
             limit(limit).
             order("#{quoted_table_name}.#{quoted_position_column} ASC")
         end
@@ -456,7 +456,7 @@ module ActiveRecord
 
           def internal_scope_changed?
             return @scope_changed if defined?(@scope_changed)
-            
+
             @scope_changed = scope_changed?
           end
 

--- a/test/test_joined_list.rb
+++ b/test/test_joined_list.rb
@@ -1,0 +1,64 @@
+require 'helper'
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Schema.verbose = false
+
+class Section < ActiveRecord::Base
+  has_many :items
+  acts_as_list
+
+  scope :visible, -> { where(visible: true) }
+end
+
+class Item < ActiveRecord::Base
+  belongs_to :section
+  acts_as_list scope: :section
+
+  scope :visible, -> { where(visible: true).joins(:section).merge(Section.visible) }
+end
+
+class JoinedTestCase < Minitest::Test
+  def setup
+    ActiveRecord::Base.connection.create_table :sections do |t|
+      t.column :position, :integer
+      t.column :visible, :boolean, default: true
+    end
+
+    ActiveRecord::Base.connection.create_table :items do |t|
+      t.column :position, :integer
+      t.column :section_id, :integer
+      t.column :visible, :boolean, default: true
+    end
+
+    ActiveRecord::Base.connection.schema_cache.clear!
+    [Section, Item].each(&:reset_column_information)
+    super
+  end
+
+  def teardown
+    ActiveRecord::Base.connection.tables.each do |table|
+      ActiveRecord::Base.connection.drop_table(table)
+    end
+    super
+  end
+end
+
+# joining the relation returned by `#higher_items` or `#lower_items` to another table
+# previously could result in ambiguous column names in the query
+class TestHigherLowerItems < JoinedTestCase
+  def test_higher_items
+    section = Section.create
+    item1 = Item.create section: section
+    item2 = Item.create section: section
+    item3 = Item.create section: section
+    assert_equal item3.higher_items.visible, [item1, item2]
+  end
+
+  def test_lower_items
+    section = Section.create
+    item1 = Item.create section: section
+    item2 = Item.create section: section
+    item3 = Item.create section: section
+    assert_equal item1.lower_items.visible, [item2, item3]
+  end
+end


### PR DESCRIPTION
Joining the relation returned by `#higher_items` or `#lower_items` to a table also having `position_column` would result in an ambiguous column error.

The new test file might be a bit heavy handed, but `test_list.rb` is somewhat...opaque. :)

The test cases are pretty close to my actual use case, and I admit that it's a slightly awkward one.
I have a `visible` scope on `Item` that joins on `Section`, but in the case of the query set returned by `lower_items`, it's already scoped to a particular `Section`.
So I could just say `.where(visible: true)` instead of `.visible`, which would avoid the unnecessary join, and I'll probably just do that in the meantime.

Still, I think this is probably a change for the better.