### PR TITLE
Passing string to define callback is deprecated in rails 5

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -123,7 +123,7 @@ module ActiveRecord
           EOV
 
           if configuration[:add_new_at].present?
-            self.send(:before_create, "add_to_list_#{configuration[:add_new_at]}")
+            self.send(:before_create, "add_to_list_#{configuration[:add_new_at]}".to_sym)
           end
 
         end


### PR DESCRIPTION
Fixes this warning.

```
DEPRECATION WARNING: Passing string to define callback is deprecated and will be removed in Rails 5.1 without replacement. (called from acts_as_list at ~/.rvm/gems/ruby-2.2.4/bundler/gems/acts_as_list/lib/acts_as_list/active_record/acts/list.rb:126)
```