### PR TITLE
Remove deprecation warning in Rails 5

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -123,7 +123,7 @@ module ActiveRecord
           EOV
 
           if configuration[:add_new_at].present?
-            self.send(:before_create, "add_to_list_#{configuration[:add_new_at]}")
+            self.send(:before_create, :"add_to_list_#{configuration[:add_new_at]}")
           end
 
         end


### PR DESCRIPTION
```
DEPRECATION WARNING: Passing string to define callback is deprecated and will be removed in Rails 5.1 without replacement. (called from acts_as_list at /Users/matt/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/acts_as_list-0a4ad6b22bc6/lib/acts_as_list/active_record/acts/list.rb:126)
```

Pretty self-explanatory fix :smile: 