### PR TITLE
Remove deprecation warning in Rails 5 caused by defining a callback with a string

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -123,7 +123,7 @@ module ActiveRecord
           EOV
 
           if configuration[:add_new_at].present?
-            self.send(:before_create, "add_to_list_#{configuration[:add_new_at]}")
+            self.send(:before_create, :"add_to_list_#{configuration[:add_new_at]}")
           end
 
         end


### PR DESCRIPTION
Pretty self-explanatory. Should be no issues.