### PR TITLE
Use a symbol as a string to define callback

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -123,7 +123,7 @@ module ActiveRecord
           EOV
 
           if configuration[:add_new_at].present?
-            self.send(:before_create, "add_to_list_#{configuration[:add_new_at]}")
+            self.send :before_create, :"add_to_list_#{configuration[:add_new_at]}"
           end
 
         end


### PR DESCRIPTION
This is required for Rails 5 support.