### PR TITLE
Update list.rb

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -125,7 +125,7 @@ module ActiveRecord
           EOV
 
           if configuration[:add_new_at].present?
-            self.send :before_create, :"add_to_list_#{configuration[:add_new_at]}"
+            self.send :before_create, "add_to_list_#{configuration[:add_new_at]}".to_sym
           end
 
         end


### PR DESCRIPTION
Passing string to define callback is deprecated and will be removed in Rails 5.1 without replacement.