### PR TITLE
Lock! the record before destroying

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -113,7 +113,7 @@ module ActiveRecord
 
             before_validation :check_top_position
             
-            before_destroy :reload_position
+            before_destroy :lock!
             after_destroy :decrement_positions_on_lower_items
             
             before_update :check_scope
@@ -475,10 +475,6 @@ module ActiveRecord
               swap_changed_attributes
               send("add_to_list_#{add_new_at}")
             end
-          end
-
-          def reload_position
-            self.reload
           end
 
           # This check is skipped if the position is currently the default position from the table

--- a/test/shared_list.rb
+++ b/test/shared_list.rb
@@ -246,5 +246,11 @@ module Shared
 
       assert_equal [5, 1, 6, 2, 3, 4], ListMixin.where(parent_id: 5).order('pos').map(&:id)
     end
+
+    def test_non_persisted_records_dont_get_lock_called
+      new = ListMixin.new(parent_id: 5)
+
+      new.destroy
+    end
   end
 end


### PR DESCRIPTION
This is instead of reloading. `lock!` also conditionally reloads if the
record is persisted. Fixes #122.