### PR TITLE
Removed duplicated assignment

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -346,7 +346,6 @@ module ActiveRecord
 
           # Returns the bottom item
           def bottom_item(except = nil)
-            conditions = scope_condition
             conditions = except ? "#{self.class.primary_key} != #{self.class.connection.quote(except.id)}" : {}
             acts_as_list_list.in_list.where(
               conditions


### PR DESCRIPTION
`conditions` is set twice in `#bottom_item` method. Remove the first assignment since it gets override by the next.