### PR TITLE
Fix position when no serial positions

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -260,8 +260,8 @@ module ActiveRecord
           position_value = send(position_column)
           acts_as_list_list.
             where("#{quoted_table_name}.#{quoted_position_column} < ?", position_value).
-            limit(limit).
-            order("#{quoted_table_name}.#{quoted_position_column} DESC")
+            order("#{quoted_table_name}.#{quoted_position_column} DESC").
+            limit(limit)
         end
 
         # Return the next lower item in the list.
@@ -277,8 +277,8 @@ module ActiveRecord
           position_value = send(position_column)
           acts_as_list_list.
             where("#{quoted_table_name}.#{quoted_position_column} > ?", position_value).
-            limit(limit).
-            order("#{quoted_table_name}.#{quoted_position_column} ASC")
+            order("#{quoted_table_name}.#{quoted_position_column} ASC").
+            limit(limit)
         end
 
         # Test if this record is in a list

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -43,6 +43,32 @@ module Shared
       assert_nil ListMixin.where(id: 4).first.lower_item
     end
 
+    def test_next_prev_not_regular_sequence
+      ListMixin.all.map do |item|
+        item.update(pos: item.pos * 5)
+      end
+
+      assert_equal [1, 2, 3, 4], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+
+      ListMixin.where(id: 2).first.move_lower
+      assert_equal [1, 3, 2, 4], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+
+      ListMixin.where(id: 2).first.move_higher
+      assert_equal [1, 2, 3, 4], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+
+      ListMixin.where(id: 1).first.move_to_bottom
+      assert_equal [2, 3, 4, 1], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+
+      ListMixin.where(id: 1).first.move_to_top
+      assert_equal [1, 2, 3, 4], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+
+      ListMixin.where(id: 2).first.move_to_bottom
+      assert_equal [1, 3, 4, 2], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+
+      ListMixin.where(id: 4).first.move_to_top
+      assert_equal [4, 1, 3, 2], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+    end
+
     def test_next_prev_groups
       li1 = ListMixin.where(id: 1).first
       li2 = ListMixin.where(id: 2).first


### PR DESCRIPTION
Tasks:
- [ ] Fix position in case of interrupted position data in the database. It should work in the event of positions of elements: `[15, 25, 55]`.