### PR TITLE
Refactor class_eval with string into class_eval with block

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gemspec
 gem "rake"
 gem "appraisal"
 gem "github_changelog_generator", "1.9.0"
+# Rack 2.0.1 breaks the build for Ruby < 2.2.2
+gem "rack", "< 2.0"
 
 group :test do
 	gem "minitest", "~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,8 @@ gemspec
 gem "rake"
 gem "appraisal"
 gem "github_changelog_generator", "1.9.0"
-# Rack 2.0.1 breaks the build for Ruby < 2.2.2
-gem "rack", "< 2.0"
 
 group :test do
-	gem "minitest", "~> 5.0"
+  gem "minitest", "~> 5.0"
   gem "test_after_commit", "~> 0.4.2"
 end

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -113,7 +113,7 @@ module ActiveRecord
             end
 
             define_singleton_method :quoted_position_column do
-              connection.quote_column_name(configuration[:column])
+              @_quoted_position_column ||= connection.quote_column_name(configuration[:column])
             end
 
             define_singleton_method :quoted_position_column_with_table_name do

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -42,7 +42,7 @@ module ActiveRecord
             configuration[:scope] = :"#{configuration[:scope]}_id"
           end
 
-          class_calling_acts_as_list = self
+          caller_class = self
 
           class_eval do
             define_singleton_method :acts_as_list_top do
@@ -54,7 +54,7 @@ module ActiveRecord
             end
 
             define_method :acts_as_list_class do
-              class_calling_acts_as_list
+              caller_class
             end
 
             define_method :position_column do

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -108,16 +108,12 @@ module ActiveRecord
               attr_accessible :"#{configuration[:column]}"
             end
 
-            define_singleton_method :quoted_table_name do
-              @_quoted_table_name ||= acts_as_list_class.quoted_table_name
-            end
-
             define_singleton_method :quoted_position_column do
               @_quoted_position_column ||= connection.quote_column_name(configuration[:column])
             end
 
             define_singleton_method :quoted_position_column_with_table_name do
-              @_quoted_position_column_with_table_name ||= "#{quoted_table_name}.#{quoted_position_column}"
+              @_quoted_position_column_with_table_name ||= "#{caller_class.quoted_table_name}.#{quoted_position_column}"
             end
 
             scope :in_list, lambda { where("#{quoted_position_column_with_table_name} IS NOT NULL") }

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -42,102 +42,106 @@ module ActiveRecord
             configuration[:scope] = :"#{configuration[:scope]}_id"
           end
 
-          if configuration[:scope].is_a?(Symbol)
-            scope_methods = %(
-              def scope_condition
-                { #{configuration[:scope]}: send(:#{configuration[:scope]}) }
+          class_calling_acts_as_list = self
+
+          class_eval do
+            define_singleton_method :acts_as_list_top do
+              configuration[:top_of_list].to_i
+            end
+
+            define_method :acts_as_list_top do
+              configuration[:top_of_list].to_i
+            end
+
+            define_method :acts_as_list_class do
+              class_calling_acts_as_list
+            end
+
+            define_method :position_column do
+              configuration[:column]
+            end
+
+            define_method :scope_name do
+              configuration[:scope]
+            end
+
+            define_method :add_new_at do
+              configuration[:add_new_at]
+            end
+
+            define_method :"#{configuration[:column]}=" do |position|
+              write_attribute(configuration[:column], position)
+              @position_changed = true
+            end
+
+            if configuration[:scope].is_a?(Symbol)
+              define_method :scope_condition do
+                { configuration[:scope] => send(:"#{configuration[:scope]}") }
               end
 
-              def scope_changed?
+              define_method :scope_changed? do
                 changed.include?(scope_name.to_s)
               end
-            )
-          elsif configuration[:scope].is_a?(Array)
-            scope_methods = %(
-              def scope_condition
-                #{configuration[:scope]}.inject({}) do |hash, column|
+            elsif configuration[:scope].is_a?(Array)
+              define_method :scope_condition do
+                configuration[:scope].inject({}) do |hash, column|
                   hash.merge!({ column.to_sym => read_attribute(column.to_sym) })
                 end
               end
 
-              def scope_changed?
+              define_method :scope_changed? do
                 (scope_condition.keys & changed.map(&:to_sym)).any?
               end
-            )
-          else
-            scope_methods = %(
-              def scope_condition
-                "#{configuration[:scope]}"
+            else
+              define_method :scope_condition do
+                eval "%{#{configuration[:scope]}}"
               end
 
-              def scope_changed?() false end
-            )
-          end
-
-          quoted_position_column = connection.quote_column_name(configuration[:column])
-          quoted_position_column_with_table_name = "#{quoted_table_name}.#{quoted_position_column}"
-
-          class_eval <<-EOV, __FILE__, __LINE__ + 1
-            def self.acts_as_list_top
-              #{configuration[:top_of_list]}.to_i
+              define_method :scope_changed? do
+                false
+              end
             end
-
-            def acts_as_list_top
-              #{configuration[:top_of_list]}.to_i
-            end
-
-            def acts_as_list_class
-              ::#{self.name}
-            end
-
-            def position_column
-              '#{configuration[:column]}'
-            end
-
-            def scope_name
-              '#{configuration[:scope]}'
-            end
-
-            def add_new_at
-              '#{configuration[:add_new_at]}'
-            end
-
-            def #{configuration[:column]}=(position)
-              write_attribute(:#{configuration[:column]}, position)
-              @position_changed = true
-            end
-
-            #{scope_methods}
 
             # only add to attr_accessible
             # if the class has some mass_assignment_protection
-
             if defined?(accessible_attributes) and !accessible_attributes.blank?
-              attr_accessible :#{configuration[:column]}
+              attr_accessible :"#{configuration[:column]}"
             end
 
-            scope :in_list, lambda { where(%q{#{quoted_position_column_with_table_name} IS NOT NULL}) }
-
-            def self.decrement_all
-              update_all_with_touch %q(#{quoted_position_column} = (#{quoted_position_column_with_table_name} - 1))
+            define_singleton_method :quoted_table_name do
+              @_quoted_table_name ||= acts_as_list_class.quoted_table_name
             end
 
-            def self.increment_all
-              update_all_with_touch %q(#{quoted_position_column} = (#{quoted_position_column_with_table_name} + 1))
+            define_singleton_method :quoted_position_column do
+              connection.quote_column_name(configuration[:column])
             end
 
-            def self.update_all_with_touch(updates)
+            define_singleton_method :quoted_position_column_with_table_name do
+              @_quoted_position_column_with_table_name ||= "#{quoted_table_name}.#{quoted_position_column}"
+            end
+
+            scope :in_list, lambda { where("#{quoted_position_column_with_table_name} IS NOT NULL") }
+
+            define_singleton_method :decrement_all do
+              update_all_with_touch "#{quoted_position_column} = (#{quoted_position_column_with_table_name} - 1)"
+            end
+
+            define_singleton_method :increment_all do
+              update_all_with_touch "#{quoted_position_column} = (#{quoted_position_column_with_table_name} + 1)"
+            end
+
+            define_singleton_method :update_all_with_touch do |updates|
               record = new
               attrs = record.send(:timestamp_attributes_for_update_in_model)
               now = record.send(:current_time_from_proper_timezone)
 
-              query = attrs.map { |attr| %(\#{connection.quote_column_name(attr)} = :now) }
+              query = attrs.map { |attr| "#{connection.quote_column_name(attr)} = :now" }
               query.push updates
               query = query.join(", ")
 
               update_all([query, now: now])
             end
-          EOV
+          end
 
           attr_reader :position_changed
 


### PR DESCRIPTION
This commit changes the "`class_eval` with string"-style to "`class_eval` with block"-style.

The only worry I have is the remaining string `eval` in the method definition on line 96:

```ruby
              define_method :scope_condition do
                eval "%{#{configuration[:scope]}}"
              end
```

Of course this eval happens in the current code, but just isn't that obvious as it is now.

Added bonus is that the position column is now quoted lazily, removing the need of an established database connection at model load-time, as mentioned in #214.

(Now let's see if all supported Ruby versions agree with this, Travis will let us know soon 😉)