### PR TITLE
Update Appraisals to fix Travis build

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,9 +1,15 @@
 appraise "rails-3-2" do
   gem "activerecord", "~> 3.2.21"
+  group :test do
+    gem "after_commit_exception_notification"
+  end
 end
 
 appraise "rails-4-1" do
   gem "activerecord", "~> 4.1.10"
+  group :test do
+    gem "after_commit_exception_notification"
+  end
 end
 
 appraise "rails-4-2" do

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,10 @@ gem "rake"
 gem "appraisal"
 # Used to automatically generate changelog file
 gem "github_changelog_generator", "1.9.0"
+# Rack 2.0.1 breaks the build for Ruby < 2.2.2
+gem "rack", "< 2.0"
 
 group :test do
-	gem "minitest", "~> 5.0"
+  gem "minitest", "~> 5.0"
   gem "test_after_commit", "~> 0.4.2"
 end

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -7,6 +7,7 @@ gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
 gem "rake"
 gem "appraisal"
 gem "github_changelog_generator", "1.9.0"
+gem "rack", "< 2.0"
 gem "activerecord", "~> 3.2.21"
 
 group :test do

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -7,6 +7,7 @@ gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
 gem "rake"
 gem "appraisal"
 gem "github_changelog_generator", "1.9.0"
+gem "rack", "< 2.0"
 gem "activerecord", "~> 4.1.10"
 
 group :test do

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -7,6 +7,7 @@ gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
 gem "rake"
 gem "appraisal"
 gem "github_changelog_generator", "1.9.0"
+gem "rack", "< 2.0"
 gem "activerecord", "~> 4.2.1"
 
 group :test do

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -7,7 +7,8 @@ gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
 gem "rake"
 gem "appraisal"
 gem "github_changelog_generator", "1.9.0"
-gem "activerecord", "~> 5.0.0.beta3"
+gem "rack", "< 2.0"
+gem "activerecord", "~> 5.0.0.rc2"
 
 group :test do
   gem "minitest", "~> 5.0"


### PR DESCRIPTION
Forces use of `rack` < `2.0`. I've also updated and installed the Appraisals to match some previous manual edits of those Gemfiles.

(Hopefully this actually fixes the build 😉)