### PR TITLE
Appraisals cleanup

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,21 @@
 appraise "rails-3-2" do
-  gem "activerecord", "~> 3.2.21"
+  gem "activerecord", "~> 3.2.22.2"
+  group :test do
+    gem "after_commit_exception_notification"
+  end
 end
 
 appraise "rails-4-1" do
-  gem "activerecord", "~> 4.1.10"
+  gem "activerecord", "~> 4.1.16"
+  group :test do
+    gem "after_commit_exception_notification"
+  end
 end
 
 appraise "rails-4-2" do
-  gem "activerecord", "~> 4.2.1"
+  gem "activerecord", "~> 4.2.7"
 end
 
 appraise "rails-5-0" do
-  gem "activerecord", "~> 5.0.0.rc2"
+  gem "activerecord", "~> 5.0.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,11 +15,7 @@ gemspec
 
 gem "rake"
 gem "appraisal"
-
-group :development do
-	# Used to automatically generate changelog file
-	gem "github_changelog_generator", "1.9.0"
-end
+gem "github_changelog_generator", "1.9.0"
 
 group :test do
 	gem "minitest", "~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -9,13 +9,15 @@ platforms :rbx do
   gem "rubysl-test-unit"
 end
 
-# Specify your gem"s dependencies in acts_as_list-rails3.gemspec
 gemspec
 
 gem "rake"
 gem "appraisal"
-# Used to automatically generate changelog file
-gem "github_changelog_generator", "1.9.0"
+
+group :development do
+	# Used to automatically generate changelog file
+	gem "github_changelog_generator", "1.9.0"
+end
 
 group :test do
 	gem "minitest", "~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ platforms :rbx do
   gem "rubysl-test-unit"
 end
 
+gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
+
 gemspec
 
 gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ platforms :rbx do
   gem "rubysl-test-unit"
 end
 
-gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
+gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21, :jruby]
 
 gemspec
 

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
+gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21]
 gem "rake"
 gem "appraisal"
 gem "activerecord", "~> 3.2.22.2"

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -6,8 +6,11 @@ gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
 gem "rake"
 gem "appraisal"
-gem "github_changelog_generator", "1.9.0"
-gem "activerecord", "~> 3.2.21"
+gem "activerecord", "~> 3.2.22.2"
+
+group :development do
+  gem "github_changelog_generator", "1.9.0"
+end
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -4,14 +4,11 @@ source "http://rubygems.org"
 
 gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
-gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21]
+gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21, :jruby]
 gem "rake"
 gem "appraisal"
+gem "github_changelog_generator", "1.9.0"
 gem "activerecord", "~> 3.2.22.2"
-
-group :development do
-  gem "github_changelog_generator", "1.9.0"
-end
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
+gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21]
 gem "rake"
 gem "appraisal"
 gem "activerecord", "~> 4.1.16"

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -4,14 +4,11 @@ source "http://rubygems.org"
 
 gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
-gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21]
+gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21, :jruby]
 gem "rake"
 gem "appraisal"
+gem "github_changelog_generator", "1.9.0"
 gem "activerecord", "~> 4.1.16"
-
-group :development do
-  gem "github_changelog_generator", "1.9.0"
-end
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -6,8 +6,11 @@ gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
 gem "rake"
 gem "appraisal"
-gem "github_changelog_generator", "1.9.0"
-gem "activerecord", "~> 4.1.10"
+gem "activerecord", "~> 4.1.16"
+
+group :development do
+  gem "github_changelog_generator", "1.9.0"
+end
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -6,8 +6,11 @@ gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
 gem "rake"
 gem "appraisal"
-gem "github_changelog_generator", "1.9.0"
-gem "activerecord", "~> 4.2.1"
+gem "activerecord", "~> 4.2.7"
+
+group :development do
+  gem "github_changelog_generator", "1.9.0"
+end
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
+gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21]
 gem "rake"
 gem "appraisal"
 gem "activerecord", "~> 4.2.7"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -4,14 +4,11 @@ source "http://rubygems.org"
 
 gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
-gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21]
+gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21, :jruby]
 gem "rake"
 gem "appraisal"
+gem "github_changelog_generator", "1.9.0"
 gem "activerecord", "~> 4.2.7"
-
-group :development do
-  gem "github_changelog_generator", "1.9.0"
-end
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
+gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21]
 gem "rake"
 gem "appraisal"
 gem "activerecord", "~> 5.0.0"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -4,14 +4,11 @@ source "http://rubygems.org"
 
 gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
-gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21]
+gem "rack", "~> 1", :platforms => [:ruby_19, :ruby_20, :ruby_21, :jruby]
 gem "rake"
 gem "appraisal"
+gem "github_changelog_generator", "1.9.0"
 gem "activerecord", "~> 5.0.0"
-
-group :development do
-  gem "github_changelog_generator", "1.9.0"
-end
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -6,8 +6,11 @@ gem "sqlite3", :platforms => [:ruby]
 gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
 gem "rake"
 gem "appraisal"
-gem "github_changelog_generator", "1.9.0"
-gem "activerecord", "~> 5.0.0.beta3"
+gem "activerecord", "~> 5.0.0"
+
+group :development do
+  gem "github_changelog_generator", "1.9.0"
+end
 
 group :test do
   gem "minitest", "~> 5.0"


### PR DESCRIPTION
I modified the appraisal gemfiles manually at some point. This fixes that problem and also the problem whereby bundler was trying to install a version of rack that is incompatible with Ruby 2.1 and below.