### PR TITLE
Add quoted table names to some columns

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -501,7 +501,7 @@ module ActiveRecord
           end
 
           def quoted_position_column_with_table_name
-            "#{quoted_table_name}.#{quoted_position_column}"
+            @_quoted_position_column_with_table_name ||= "#{quoted_table_name}.#{quoted_position_column}"
           end
       end
     end


### PR DESCRIPTION
When I'm using custom `acts_as_list_list` with `joins` I have an error: `column reference "id" is ambiguous`. We need to specify table name in some places to prevent this error. 