### PR TITLE
Show items with same position in higher and lower items

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -262,7 +262,7 @@ module ActiveRecord
 
         # Return the next n higher items in the list
         # selects all higher items by default
-        def higher_items(limit = nil)
+        def higher_items(limit=nil)
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
@@ -280,7 +280,7 @@ module ActiveRecord
 
         # Return the next n lower items in the list
         # selects all lower items by default
-        def lower_items(limit = nil)
+        def lower_items(limit=nil)
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -262,11 +262,12 @@ module ActiveRecord
 
         # Return the next n higher items in the list
         # selects all higher items by default
-        def higher_items(limit=nil)
+        def higher_items(limit = nil)
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
-            where("#{quoted_position_column_with_table_name} < ?", position_value).
+            where("#{quoted_position_column_with_table_name} <= ?", position_value).
+            where("#{quoted_table_name}.#{self.class.primary_key} != ?", self.send(self.class.primary_key)).
             order("#{quoted_position_column_with_table_name} DESC").
             limit(limit)
         end
@@ -279,11 +280,12 @@ module ActiveRecord
 
         # Return the next n lower items in the list
         # selects all lower items by default
-        def lower_items(limit=nil)
+        def lower_items(limit = nil)
           limit ||= acts_as_list_list.count
           position_value = send(position_column)
           acts_as_list_list.
-            where("#{quoted_position_column_with_table_name} > ?", position_value).
+            where("#{quoted_position_column_with_table_name} >= ?", position_value).
+            where("#{quoted_table_name}.#{self.class.primary_key} != ?", self.send(self.class.primary_key)).
             order("#{quoted_position_column_with_table_name} ASC").
             limit(limit)
         end

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -85,6 +85,23 @@ module Shared
       assert_equal [], li1.higher_items
     end
 
+    def test_next_prev_groups_with_same_position
+      li1 = ListMixin.where(id: 1).first
+      li2 = ListMixin.where(id: 2).first
+      li3 = ListMixin.where(id: 3).first
+      li4 = ListMixin.where(id: 4).first
+
+      li3.update_columns(pos: 2) # Make the same position as li2
+
+      assert_equal [1, 2, 2, 4], ListMixin.pluck(:pos)
+
+      assert_equal [li3, li4], li2.lower_items
+      assert_equal [li2, li4], li3.lower_items
+
+      assert_equal [li3, li1], li2.higher_items
+      assert_equal [li2, li1], li3.higher_items
+    end
+
     def test_injection
       item = ListMixin.new("parent_id"=>1)
       assert_equal({ parent_id: 1 }, item.scope_condition)

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -91,7 +91,7 @@ module Shared
       li3 = ListMixin.where(id: 3).first
       li4 = ListMixin.where(id: 4).first
 
-      li3.update_columns(pos: 2) # Make the same position as li2
+      li3.update_column(:pos, 2) # Make the same position as li2
 
       assert_equal [1, 2, 2, 4], ListMixin.pluck(:pos)
 


### PR DESCRIPTION
Currently, when we're trying to move up and down items with same positions, they are not found in scope, because they have the same id. We need to show all items with the same id but exclude current one. 

@brendon can you take a look ?

