### PR TITLE
Fix non regular sequence movement

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -217,8 +217,10 @@ module ActiveRecord
         private
 
           def swap_positions(item1, item2)
+            item1_position = item1.send(position_column)
+
             item1.set_list_position(item2.send(position_column))
-            item2.set_list_position(item1.send("#{position_column}_was"))
+            item2.set_list_position(item1_position)
           end
 
           def acts_as_list_list

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -49,12 +49,16 @@ module Shared
       end
 
       assert_equal [1, 2, 3, 4], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+      assert_equal [5, 10, 15, 20], ListMixin.where(parent_id: 5000).map(&:pos)
 
       ListMixin.where(id: 2).first.move_lower
       assert_equal [1, 3, 2, 4], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+      assert_equal [5, 15, 10, 20], ListMixin.where(parent_id: 5000).map(&:pos)
+
 
       ListMixin.where(id: 2).first.move_higher
       assert_equal [1, 2, 3, 4], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+      assert_equal [5, 10, 15, 20], ListMixin.where(parent_id: 5000).map(&:pos)
 
       ListMixin.where(id: 1).first.move_to_bottom
       assert_equal [2, 3, 4, 1], ListMixin.where(parent_id: 5000).order('pos').map(&:id)


### PR DESCRIPTION
#223 Introduced a bug, by adding the branch condition to `move_lower` and `move_higher`, the order is still changed but if you are using a before save callback to spy on position change, the position for the second element is the same as the original due to a mistake in `lib/acts_as_list/active_record/acts/list.rb:221`

### Previously:
```ruby
# lib/acts_as_list/active_record/acts/list.rb:74
def move_lower
  return unless lower_item

  acts_as_list_class.transaction do
    if lower_item.send(position_column) == self.send(position_column)
      swap_positions(lower_item, self)
    else
      lower_item.decrement_position
      increment_position
    end
  end
end
```
This condition is checking that booth elements don't have the same position.

This changed behaviour not only for non regular sequence positions, but for all elements that don't have the same position, I argue this should only be entered for elements with a absolute distance between them bigger that 1.

Elements with a pair of positions `[1,2]` and ` [1,5]` will enter this condition, was this on propose? 

`swap_position` doesn't do the same as the other part of the conditional branch for elements with positions `1` and `2`.

```ruby
# lib/acts_as_list/active_record/acts/list.rb:219
def swap_positions(item1, item2)
  item1.set_list_position(item2.send(position_column))
  item2.set_list_position(item1.send("#{position_column}_was"))
end
```

`item1.send("#{position_column}_was")` returns the same as `item1.send(position_column)` so my proposed solution it's to store item1 original position in a variable before we change it's position.