### PR TITLE
Don't update a child destroyed via relation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "minitest", "~> 5.0"
   gem "test_after_commit", "~> 0.4.2"
   gem "timecop"
+  gem "mocha"
 end
 
 group :sqlite do

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "minitest", "~> 5.0"
   gem "test_after_commit", "~> 0.4.2"
   gem "timecop"
+  gem "mocha"
   gem "after_commit_exception_notification"
 end
 

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "minitest", "~> 5.0"
   gem "test_after_commit", "~> 0.4.2"
   gem "timecop"
+  gem "mocha"
   gem "after_commit_exception_notification"
 end
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "minitest", "~> 5.0"
   gem "test_after_commit", "~> 0.4.2"
   gem "timecop"
+  gem "mocha"
 end
 
 group :sqlite do

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "minitest", "~> 5.0"
   gem "test_after_commit", "~> 0.4.2"
   gem "timecop"
+  gem "mocha"
 end
 
 group :sqlite do

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "minitest", "~> 5.0"
   gem "test_after_commit", "~> 0.4.2"
   gem "timecop"
+  gem "mocha"
 end
 
 group :sqlite do

--- a/lib/acts_as_list/active_record/acts/callback_definer.rb
+++ b/lib/acts_as_list/active_record/acts/callback_definer.rb
@@ -3,9 +3,7 @@ module ActiveRecord::Acts::List::CallbackDefiner #:nodoc:
     caller_class.class_eval do
       before_validation :check_top_position, unless: :act_as_list_no_update?
 
-      # lock! reloads the record and we lose the destroyed_by_association information
-      # so set_destroyed_by_association_foreign_key must come first
-      before_destroy :set_destroyed_by_association_foreign_key, :lock!
+      before_destroy :lock!, unless: "destroyed_via_scope? || act_as_list_no_update?"
       after_destroy :decrement_positions_on_lower_items, unless: "destroyed_via_scope? || act_as_list_no_update?"
 
       before_update :check_scope, unless: :act_as_list_no_update?

--- a/lib/acts_as_list/active_record/acts/callback_definer.rb
+++ b/lib/acts_as_list/active_record/acts/callback_definer.rb
@@ -4,7 +4,7 @@ module ActiveRecord::Acts::List::CallbackDefiner #:nodoc:
       before_validation :check_top_position, unless: :act_as_list_no_update?
 
       before_destroy :lock!
-      after_destroy :decrement_positions_on_lower_items, unless: :act_as_list_no_update?
+      after_destroy :decrement_positions_on_lower_items, unless: "destroyed_via_scope? || act_as_list_no_update?"
 
       before_update :check_scope, unless: :act_as_list_no_update?
       after_update :update_positions, unless: :act_as_list_no_update?

--- a/lib/acts_as_list/active_record/acts/callback_definer.rb
+++ b/lib/acts_as_list/active_record/acts/callback_definer.rb
@@ -3,7 +3,9 @@ module ActiveRecord::Acts::List::CallbackDefiner #:nodoc:
     caller_class.class_eval do
       before_validation :check_top_position, unless: :act_as_list_no_update?
 
-      before_destroy :lock!
+      # lock! reloads the record and we lose the destroyed_by_association information
+      # so set_destroyed_by_association_foreign_key must come first
+      before_destroy :set_destroyed_by_association_foreign_key, :lock!
       after_destroy :decrement_positions_on_lower_items, unless: "destroyed_via_scope? || act_as_list_no_update?"
 
       before_update :check_scope, unless: :act_as_list_no_update?

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -410,10 +410,6 @@ module ActiveRecord
           end
         end
 
-        def set_destroyed_by_association_foreign_key
-          @destroyed_by_association_foreign_key = destroyed_by_association && destroyed_by_association.foreign_key
-        end
-
         def internal_scope_changed?
           return @scope_changed if defined?(@scope_changed)
 

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -410,6 +410,10 @@ module ActiveRecord
           end
         end
 
+        def set_destroyed_by_association_foreign_key
+          @destroyed_by_association_foreign_key = destroyed_by_association && destroyed_by_association.foreign_key
+        end
+
         def internal_scope_changed?
           return @scope_changed if defined?(@scope_changed)
 

--- a/lib/acts_as_list/active_record/acts/scope_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/scope_method_definer.rb
@@ -17,6 +17,10 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         define_method :scope_changed? do
           changed.include?(scope_name.to_s)
         end
+
+        define_method :destroyed_via_scope? do
+          destroyed_by_association.second.foreign_key == scope.to_s
+        end
       elsif scope.is_a?(Array)
         define_method :scope_condition do
           scope.inject({}) do |hash, column|
@@ -27,12 +31,20 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         define_method :scope_changed? do
           (scope_condition.keys & changed.map(&:to_sym)).any?
         end
+
+        define_method :destroyed_via_scope? do
+          scope_condition.keys.include? destroyed_by_association.second.foreign_key.to_sym
+        end
       else
         define_method :scope_condition do
           eval "%{#{scope}}"
         end
 
         define_method :scope_changed? do
+          false
+        end
+
+        define_method :destroyed_via_scope? do
           false
         end
       end

--- a/lib/acts_as_list/active_record/acts/scope_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/scope_method_definer.rb
@@ -19,8 +19,8 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         end
 
         define_method :destroyed_via_scope? do
-          return false unless @destroyed_by_association_foreign_key
-          @destroyed_by_association_foreign_key.to_sym == scope
+          return false if ActiveRecord::VERSION::MAJOR < 4
+          scope == (destroyed_by_association && destroyed_by_association.foreign_key.to_sym)
         end
       elsif scope.is_a?(Array)
         define_method :scope_condition do
@@ -34,8 +34,8 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         end
 
         define_method :destroyed_via_scope? do
-          return false unless @destroyed_by_association_foreign_key
-          scope_condition.keys.include? @destroyed_by_association_foreign_key
+          return false if ActiveRecord::VERSION::MAJOR < 4
+          scope_condition.keys.include? (destroyed_by_association && destroyed_by_association.foreign_key.to_sym)
         end
       else
         define_method :scope_condition do

--- a/lib/acts_as_list/active_record/acts/scope_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/scope_method_definer.rb
@@ -19,7 +19,8 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         end
 
         define_method :destroyed_via_scope? do
-          destroyed_by_association.second.foreign_key == scope.to_s
+          return false unless @destroyed_by_association_foreign_key
+          @destroyed_by_association_foreign_key.to_sym == scope
         end
       elsif scope.is_a?(Array)
         define_method :scope_condition do
@@ -33,7 +34,8 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         end
 
         define_method :destroyed_via_scope? do
-          scope_condition.keys.include? destroyed_by_association.second.foreign_key.to_sym
+          return false unless @destroyed_by_association_foreign_key
+          scope_condition.keys.include? @destroyed_by_association_foreign_key
         end
       else
         define_method :scope_condition do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,7 @@ rescue Bundler::BundlerError => e
 end
 require "active_record"
 require "minitest/autorun"
+require "mocha/mini_test"
 require "#{File.dirname(__FILE__)}/../init"
 
 if defined?(ActiveRecord::VERSION) &&

--- a/test/test_no_update_for_extra_classes.rb
+++ b/test/test_no_update_for_extra_classes.rb
@@ -33,7 +33,7 @@ class NoUpdateForCollectionClassesTestCase < Minitest::Test
     end
 
     ActiveRecord::Base.connection.schema_cache.clear!
-    [TodoList, Item, TodoItemAttachment].each(&:reset_column_information)
+    [TodoList, TodoItem, TodoItemAttachment].each(&:reset_column_information)
     super
   end
 

--- a/test/test_no_update_for_scope_destruction.rb
+++ b/test/test_no_update_for_scope_destruction.rb
@@ -51,10 +51,13 @@ class NoUpdateForScopeDestructionTestCase < Minitest::Test
     end
 
     def test_no_update_children_when_parent_destroyed
-      return if ActiveRecord::VERSION::MAJOR > 4
-
-      DestructionTodoItem.any_instance.expects(:decrement_positions_on_lower_items).never
-      DestructionTadaItem.any_instance.expects(:decrement_positions_on_lower_items).never
+      if ActiveRecord::VERSION::MAJOR < 4
+        DestructionTodoItem.any_instance.expects(:decrement_positions_on_lower_items).once
+        DestructionTadaItem.any_instance.expects(:decrement_positions_on_lower_items).once
+      else
+        DestructionTodoItem.any_instance.expects(:decrement_positions_on_lower_items).never
+        DestructionTadaItem.any_instance.expects(:decrement_positions_on_lower_items).never
+      end
       assert @list.destroy
     end
 

--- a/test/test_no_update_for_scope_destruction.rb
+++ b/test/test_no_update_for_scope_destruction.rb
@@ -50,6 +50,14 @@ class NoUpdateForScopeDestructionTestCase < Minitest::Test
       @tada_item_1 = DestructionTadaItem.create! position: 1, destruction_todo_list_id: @list.id, enabled: true
     end
 
+    def test_no_update_children_when_parent_destroyed
+      return if ActiveRecord::VERSION::MAJOR > 4
+
+      DestructionTodoItem.any_instance.expects(:decrement_positions_on_lower_items).never
+      DestructionTadaItem.any_instance.expects(:decrement_positions_on_lower_items).never
+      assert @list.destroy
+    end
+
     def test_update_children_when_sibling_destroyed
       @todo_item_1.expects(:decrement_positions_on_lower_items).once
       @tada_item_1.expects(:decrement_positions_on_lower_items).once

--- a/test/test_no_update_for_scope_destruction.rb
+++ b/test/test_no_update_for_scope_destruction.rb
@@ -2,6 +2,7 @@ require 'helper'
 
 class DestructionTodoList < ActiveRecord::Base
   has_many :destruction_todo_items, dependent: :destroy
+  has_many :destruction_tada_items, dependent: :destroy
 end
 
 class DestructionTodoItem < ActiveRecord::Base
@@ -45,14 +46,8 @@ class NoUpdateForScopeDestructionTestCase < Minitest::Test
       super
       @list = DestructionTodoList.create!
 
-      @todo_item_1, @todo_item_2, @todo_item_3 = (1..3).map { |counter| DestructionTodoItem.create!(position: counter, destruction_todo_list_id: @list.id) }
-      @tada_item_1, @tada_item_2, @tada_item_3 = (1..3).map { |counter| DestructionTadaItem.create!(position: counter, destruction_todo_list_id: @list.id, enabled: true) }
-    end
-
-    def test_no_update_children_when_parent_destroyed
-      @todo_item_1.expects(:decrement_positions_on_lower_items).never
-      @tada_item_1.expects(:decrement_positions_on_lower_items).never
-      assert @list.destroy
+      @todo_item_1 = DestructionTodoItem.create! position: 1, destruction_todo_list_id: @list.id
+      @tada_item_1 = DestructionTadaItem.create! position: 1, destruction_todo_list_id: @list.id, enabled: true
     end
 
     def test_update_children_when_sibling_destroyed

--- a/test/test_no_update_for_scope_destruction.rb
+++ b/test/test_no_update_for_scope_destruction.rb
@@ -1,0 +1,47 @@
+require 'helper'
+
+class DestructionTodoList < ActiveRecord::Base
+  has_many :destruction_todo_items, dependent: :destroy
+end
+
+class DestructionTodoItem < ActiveRecord::Base
+  belongs_to :destruction_todo_list
+  acts_as_list scope: :destruction_todo_list
+end
+
+class NoUpdateForScopeDestructionTestCase < Minitest::Test
+  def setup
+    ActiveRecord::Base.connection.create_table :destruction_todo_lists do |t|
+    end
+
+    ActiveRecord::Base.connection.create_table :destruction_todo_items do |t|
+      t.column :position, :integer
+      t.column :destruction_todo_list_id, :integer
+    end
+
+    ActiveRecord::Base.connection.schema_cache.clear!
+    [DestructionTodoList, DestructionTodoItem].each(&:reset_column_information)
+    super
+  end
+
+  def teardown
+    teardown_db
+    super
+  end
+
+  class NoUpdateForScopeDestructionTest < NoUpdateForScopeDestructionTestCase
+    def setup
+      super
+      @list = DestructionTodoList.create!
+
+      @item_1, @item_2, @item_3 = (1..3).map { |counter| DestructionTodoItem.create!(position: counter, destruction_todo_list_id: @list.id) }
+    end
+
+    def test_no_update_children_when_parent_destroyed
+      # mock = MiniTest::Mock.new
+      # mock.expects(:decrement_positions_on_lower_items).once
+      @list.destroy
+    end
+
+  end
+end

--- a/test/test_no_update_for_scope_destruction.rb
+++ b/test/test_no_update_for_scope_destruction.rb
@@ -9,6 +9,11 @@ class DestructionTodoItem < ActiveRecord::Base
   acts_as_list scope: :destruction_todo_list
 end
 
+class DestructionTadaItem < ActiveRecord::Base
+  belongs_to :destruction_todo_list
+  acts_as_list scope: [:destruction_todo_list_id, :enabled]
+end
+
 class NoUpdateForScopeDestructionTestCase < Minitest::Test
   def setup
     ActiveRecord::Base.connection.create_table :destruction_todo_lists do |t|
@@ -19,8 +24,14 @@ class NoUpdateForScopeDestructionTestCase < Minitest::Test
       t.column :destruction_todo_list_id, :integer
     end
 
+    ActiveRecord::Base.connection.create_table :destruction_tada_items do |t|
+      t.column :position, :integer
+      t.column :destruction_todo_list_id, :integer
+      t.column :enabled, :boolean
+    end
+
     ActiveRecord::Base.connection.schema_cache.clear!
-    [DestructionTodoList, DestructionTodoItem].each(&:reset_column_information)
+    [DestructionTodoList, DestructionTodoItem, DestructionTadaItem].each(&:reset_column_information)
     super
   end
 
@@ -34,13 +45,21 @@ class NoUpdateForScopeDestructionTestCase < Minitest::Test
       super
       @list = DestructionTodoList.create!
 
-      @item_1, @item_2, @item_3 = (1..3).map { |counter| DestructionTodoItem.create!(position: counter, destruction_todo_list_id: @list.id) }
+      @todo_item_1, @todo_item_2, @todo_item_3 = (1..3).map { |counter| DestructionTodoItem.create!(position: counter, destruction_todo_list_id: @list.id) }
+      @tada_item_1, @tada_item_2, @tada_item_3 = (1..3).map { |counter| DestructionTadaItem.create!(position: counter, destruction_todo_list_id: @list.id, enabled: true) }
     end
 
     def test_no_update_children_when_parent_destroyed
-      # mock = MiniTest::Mock.new
-      # mock.expects(:decrement_positions_on_lower_items).once
-      @list.destroy
+      @todo_item_1.expects(:decrement_positions_on_lower_items).never
+      @tada_item_1.expects(:decrement_positions_on_lower_items).never
+      assert @list.destroy
+    end
+
+    def test_update_children_when_sibling_destroyed
+      @todo_item_1.expects(:decrement_positions_on_lower_items).once
+      @tada_item_1.expects(:decrement_positions_on_lower_items).once
+      assert @todo_item_1.destroy
+      assert @tada_item_1.destroy
     end
 
   end


### PR DESCRIPTION
@swanandp, I've cobbled together a solution. It's actually largely inspired from the Rails code where they don't update the counter cache if they know the child is being deleted via its parent's `dependent: :destroy`.

I've become a bit stuck in how to test it. I want to test that the callback method either is or isn't called but apparently this isn't very straightforward in MiniTest. Do you have any suggestions?

@scottsherwood can you bundle this branch in your application and see if it works for you? If you're not the right Scott Sherwood, please let me know and I'll try the other one :)
