### PR TITLE
Be more surgical about unscoping

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -164,7 +164,7 @@ module ActiveRecord
           acts_as_list_list.
             where("#{quoted_position_column_with_table_name} <= ?", position_value).
             where("#{quoted_table_name}.#{self.class.primary_key} != ?", self.send(self.class.primary_key)).
-            order("#{quoted_position_column_with_table_name} DESC").
+            reorder("#{quoted_position_column_with_table_name} DESC").
             limit(limit)
         end
 
@@ -182,7 +182,7 @@ module ActiveRecord
           acts_as_list_list.
             where("#{quoted_position_column_with_table_name} >= ?", position_value).
             where("#{quoted_table_name}.#{self.class.primary_key} != ?", self.send(self.class.primary_key)).
-            order("#{quoted_position_column_with_table_name} ASC").
+            reorder("#{quoted_position_column_with_table_name} ASC").
             limit(limit)
         end
 
@@ -219,8 +219,10 @@ module ActiveRecord
         end
 
         def acts_as_list_list
-          acts_as_list_class.unscoped do
-            acts_as_list_class.where(scope_condition)
+          if ActiveRecord::VERSION::MAJOR < 4
+            acts_as_list_class.except(:where).where(scope_condition)
+          else
+            acts_as_list_class.unscope(:where).where(scope_condition)
           end
         end
 
@@ -274,7 +276,7 @@ module ActiveRecord
             scope = scope.where("#{quoted_table_name}.#{self.class.primary_key} != ?", except.id)
           end
 
-          scope.in_list.order("#{quoted_position_column_with_table_name} DESC").first
+          scope.in_list.reorder("#{quoted_position_column_with_table_name} DESC").first
         end
 
         # Forces item to assume the bottom position in the list.
@@ -346,7 +348,7 @@ module ActiveRecord
             )
 
             if sequential_updates?
-              items.order("#{quoted_position_column_with_table_name} ASC").each do |item|
+              items.reorder("#{quoted_position_column_with_table_name} ASC").each do |item|
                 item.decrement!(position_column)
               end
             else
@@ -364,7 +366,7 @@ module ActiveRecord
             )
 
             if sequential_updates?
-              items.order("#{quoted_position_column_with_table_name} DESC").each do |item|
+              items.reorder("#{quoted_position_column_with_table_name} DESC").each do |item|
                 item.increment!(position_column)
               end
             else

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -220,7 +220,9 @@ module ActiveRecord
 
         def acts_as_list_list
           if ActiveRecord::VERSION::MAJOR < 4
-            acts_as_list_class.except(:where).where(scope_condition)
+            acts_as_list_class.unscoped do
+              acts_as_list_class.where(scope_condition)
+            end
           else
             acts_as_list_class.unscope(:where).where(scope_condition)
           end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -48,6 +48,7 @@ end
 
 require "shared"
 
+# require 'logger'
 # ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 def assert_equal_or_nil(a, b)

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -103,7 +103,13 @@ class DefaultScopedWhereMixin < Mixin
   default_scope { order('pos ASC').where(active: true) }
 
   def self.for_active_false_tests
-    unscoped.order('pos ASC').where(active: false)
+    if ActiveRecord::VERSION::MAJOR < 4
+      unscoped do
+        order('pos ASC').where(active: false)
+      end
+    else
+      unscope(:where).where(active: false)
+    end
   end
 end
 


### PR DESCRIPTION
We now only remove the `where` scopes, and use `reorder` where
necessary to ensure our ordering is paramount.

Rails 3.2 compatibility is maintained via the `except` method instead
of `unscope`.

Fixes https://github.com/swanandp/acts_as_list/issues/263