### PR TITLE
Use bottom_position_in_list instead of the highest value in the table

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -382,7 +382,7 @@ module ActiveRecord
               # temporary move after bottom with gap, avoiding duplicate values
               # gap is required to leave room for position increments
               # positive number will be valid with unique not null check (>= 0) db constraint
-              temporary_position = acts_as_list_class.maximum(position_column).to_i + 2
+              temporary_position = bottom_position_in_list + 2
               set_list_position(temporary_position)
               shuffle_positions_on_intermediate_items(old_position, position, id)
             else


### PR DESCRIPTION
Fixes #264. @zharikovpro could you chime in on this one?

I can't see a good reason to have a unique constraint on the position column because unless you're using it without a scope, there will be duplicates. If you're using it without a scope, will my change in this PR still work for you? Could you test it out for me? The tests still pass, and instead of grabbing the `MAXIMUM` value via SQL, we're just grabbing the last item in the scoped list and adding `2` to that.

I'm not sure if we're testing for this scenario though a cursory glance at your original PR seems to indicate we are.

@yatish27 can you let me know if this works better for you?