### PR TITLE
Add scope when calling maximum in insert_at_position

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -382,7 +382,7 @@ module ActiveRecord
               # temporary move after bottom with gap, avoiding duplicate values
               # gap is required to leave room for position increments
               # positive number will be valid with unique not null check (>= 0) db constraint
-              temporary_position = acts_as_list_class.maximum(position_column).to_i + 2
+              temporary_position = acts_as_list_class.where(scope_condition).maximum(position_column).to_i + 2
               set_list_position(temporary_position)
               shuffle_positions_on_intermediate_items(old_position, position, id)
             else


### PR DESCRIPTION
It adds scope to `insert_at_position`. When we call `acts_as_list_class.maximum(position_column)`, it scans the entire table. We need to know the maximum with respect to the scope defined in the acts_as_list class.
This is improves performance as it will not scan the entire table.