### PR TITLE
Get higher_items and lower_items without extra database queries

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -164,9 +164,9 @@ module ActiveRecord
           limit ||= acts_as_list_list.length
           position_value = send(position_column)
           acts_as_list_list.select do |item|
-            item.send(position_column) <= position_value
+            item.send(position_column).try(:<=, position_value)
           end.select do |item|
-            item.send(self.class.primary_key) != self.send(self.class.primary_key)
+            item.send(self.class.primary_key).try(:!=, self.send(self.class.primary_key))
           end.sort do |a, b|
             b.send(position_column) <=> a.send(position_column)
           end.first(limit)
@@ -184,9 +184,9 @@ module ActiveRecord
           limit ||= acts_as_list_list.length
           position_value = send(position_column)
           acts_as_list_list.select do |item|
-            item.send(position_column) >= position_value
+            item.send(position_column).try(:>=, position_value)
           end.select do |item|
-            item.send(self.class.primary_key) != self.send(self.class.primary_key)
+            item.send(self.class.primary_key).try(:!=, self.send(self.class.primary_key))
           end.sort do |a, b|
             a.send(position_column) <=> b.send(position_column)
           end.first(limit)

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -159,12 +159,12 @@ module ActiveRecord
         end
 
         def higher_items_relation
-          ids = higher_items.pluck(:id)
+          ids = higher_items.map(&:id)
           acts_as_list_list.where(id: ids).order(position_column => :desc)
         end
 
         def lower_items_relation
-          ids = lower_items.pluck(:id)
+          ids = lower_items.map(&:id)
           acts_as_list_list.where(id: ids).order(position_column => :asc)
         end
 

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -160,12 +160,12 @@ module ActiveRecord
 
         def higher_items_relation
           ids = higher_items.map(&:id)
-          acts_as_list_list.where(id: ids).order(position_column => :desc)
+          acts_as_list_list.where(id: ids).reorder("#{quoted_position_column_with_table_name} DESC")
         end
 
         def lower_items_relation
           ids = lower_items.map(&:id)
-          acts_as_list_list.where(id: ids).order(position_column => :asc)
+          acts_as_list_list.where(id: ids).reorder("#{quoted_position_column_with_table_name} ASC")
         end
 
         # Return the next n higher items in the list

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -158,6 +158,16 @@ module ActiveRecord
           higher_items(1).first
         end
 
+        def higher_items_relation
+          ids = higher_items.pluck(:id)
+          acts_as_list_list.where(id: ids).order(position_column => :desc)
+        end
+
+        def lower_items_relation
+          ids = lower_items.pluck(:id)
+          acts_as_list_list.where(id: ids).order(position_column => :asc)
+        end
+
         # Return the next n higher items in the list
         # selects all higher items by default
         def higher_items(limit=nil)

--- a/test/test_joined_list.rb
+++ b/test/test_joined_list.rb
@@ -46,7 +46,7 @@ class TestHigherLowerItems < JoinedTestCase
     item1 = Item.create section: section
     item2 = Item.create section: section
     item3 = Item.create section: section
-    assert_equal item3.higher_items.visible, [item2, item1]
+    assert_equal item3.higher_items_relation.visible, [item2, item1]
   end
 
   def test_lower_items
@@ -54,6 +54,6 @@ class TestHigherLowerItems < JoinedTestCase
     item1 = Item.create section: section
     item2 = Item.create section: section
     item3 = Item.create section: section
-    assert_equal item1.lower_items.visible, [item2, item3]
+    assert_equal item1.lower_items_relation.visible, [item2, item3]
   end
 end


### PR DESCRIPTION
On some apps, database performance suffers quite a lot from use of this gem, since many method calls result in their own database queries. Here, I attempt to speed things up by using methods from `Enumerable` to get the same objects from `acts_as_list_list`, which we already have in memory. The difference is that these methods now return `Array`s instead of `ActiveRecord::Relation`s, so I've added more methods to get those relations back in cases where they're needed.