### PR TITLE
Fix update to scope that was defined with an enum

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -432,9 +432,9 @@ module ActiveRecord
           if internal_scope_changed?
             cached_changes = changes
 
-            cached_changes.each { |attribute, values| self[attribute] = values[0] }
+            cached_changes.each { |attribute, values| send("#{attribute}=", values[0]) }
             send('decrement_positions_on_lower_items') if lower_item
-            cached_changes.each { |attribute, values| self[attribute] = values[1] }
+            cached_changes.each { |attribute, values| send("#{attribute}=", values[1]) }
 
             send("add_to_list_#{add_new_at}") if add_new_at.present?
           end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -641,6 +641,12 @@ if rails_4
       assert_equal [1], EnumArrayScopeListMixin.where(:parent_id => 2, :state => EnumArrayScopeListMixin.states['active']).map(&:pos)
       assert_equal [1], EnumArrayScopeListMixin.where(:parent_id => 2, :state => EnumArrayScopeListMixin.states['archived']).map(&:pos)
     end
+
+    def test_update_state
+      active_item = EnumArrayScopeListMixin.find_by(:parent_id => 2, :state => EnumArrayScopeListMixin.states['active'])
+      active_item.update(state: EnumArrayScopeListMixin.states['archived'])
+      assert_equal [1, 2], EnumArrayScopeListMixin.where(:parent_id => 2, :state => EnumArrayScopeListMixin.states['archived']).map(&:pos).sort
+    end
   end
 end
 


### PR DESCRIPTION
This is a non-issue with activesupport 5.0, but prior to that, when
check_scope is assigning the attributes hash, the assignment of an enum
is invalid and results in a value of 0 being assigned as the scope.
Assigning with the enum's setter instead.

Fixes #277