### PR TITLE
Unscope `select` to avoid PG::UndefinedFunction

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -232,7 +232,7 @@ module ActiveRecord
               acts_as_list_class.where(scope_condition)
             end
           else
-            acts_as_list_class.unscope(:where).where(scope_condition)
+            acts_as_list_class.unscope(:select, :where).where(scope_condition)
           end
         end
 

--- a/test/test_default_scope_with_select.rb
+++ b/test/test_default_scope_with_select.rb
@@ -1,0 +1,33 @@
+require 'helper'
+
+class Animal < ActiveRecord::Base
+  acts_as_list
+  default_scope -> { select(:name) }
+end
+
+class DefaultScopeWithSelectTest < Minitest::Test
+  def setup
+    ActiveRecord::Base.connection.create_table :animals do |t|
+      t.column :position, :integer
+      t.column :name, :string
+    end
+
+    ActiveRecord::Base.connection.schema_cache.clear!
+    Animal.reset_column_information
+    super
+  end
+
+  def teardown
+    teardown_db
+    super
+  end
+
+  def test_default_scope_with_select
+    animal1 = Animal.create name: 'Fox'
+    animal2 = Animal.create name: 'Panda'
+    animal3 = Animal.create name: 'Wildebeast'
+    assert_equal 1, animal1.position
+    assert_equal 2, animal2.position
+    assert_equal 3, animal3.position
+  end
+end


### PR DESCRIPTION
Having a `default_scope` with a `select` breaks since acts_as_list 0.9.5.  The error type is discussed here:

https://github.com/rails/rails/issues/19146

Unscoping the `select` scope fixes the problem.