### PR TITLE
Rebalance positions in the case of duplicates

### DIFF
--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -868,4 +868,25 @@ class SequentialUpdatesMixinNotNullUniquePositiveConstraintsTest < ActsAsListTes
     new.insert_at(3)
     assert_equal 3, new.pos
   end
+
+  class DuplicatePositionRebalancingTest < ActsAsListTestCase
+    def setup
+      setup_db
+    end
+
+    def test_positions_are_unique_with_corrupted_duplicated
+      new1 = DefaultScopedMixin.create
+      new2 = DefaultScopedMixin.create
+      new3 = DefaultScopedMixin.create
+
+      new1.update_column :pos, 1
+      new2.update_column :pos, 1
+      new3.update_column :pos, 2
+
+      assert_equal [[new1.id, 1], [new2.id, 1], [new3.id, 2]], DefaultScopedMixin.all.map { |i| [i.id, i.pos] }
+
+      new4 = DefaultScopedMixin.create pos: 1
+      assert_equal [[new4.id, 1], [new1.id, 2], [new2.id, 3], [new3.id, 4]], DefaultScopedMixin.all.map { |i| [i.id, i.pos] }
+    end
+  end
 end


### PR DESCRIPTION
Hi @swanandp, I ran into this in my project where I had some buggy duplicate positions. I wondered if we should perhaps detect and fix duplicates within scopes? I think it'd be a good idea.

Do you have any ideas on how to go about it? There doesn't seem to be an easy SQL way to do it. Perhaps this:

- [ ] Detect duplicates within scope, preferably with a single SQL call while we're inserting a new record, or perhaps when incrementing/decrementing values?
- [ ] Kick off a rebalancing (probably the wrong term)