### PR TITLE
Added fixed values option for scope array

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ class TodoItem < ActiveRecord::Base
 end
 ```
 
+You can also add multiple scopes in this fashion:
+```ruby
+class TodoItem < ActiveRecord::Base
+  acts_as_list scope: [:kind, :owner_id]
+end
+```
+
+Furthermore, you can optionally include a hash of fixed parameters that will be included in all queries:
+```ruby
+class TodoItem < ActiveRecord::Base
+  acts_as_list scope: [:kind, :owner_id, deleted_at: nil]
+end
+```
+
+This is useful when using this gem in conjunction with the popular [acts_as_paranoid](https://github.com/ActsAsParanoid/acts_as_paranoid) gem.
+
 ## More Options
 - `column`
 default: `position`. Use this option if the column name in your database is different from position.

--- a/lib/acts_as_list/active_record/acts/scope_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/scope_method_definer.rb
@@ -24,8 +24,17 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         end
       elsif scope.is_a?(Array)
         define_method :scope_condition do
-          scope.inject({}) do |hash, column|
-            hash.merge!({ column.to_sym => read_attribute(column.to_sym) })
+          # The elements of the Array can be symbols, strings, or hashes.
+          # If symbols or strings, they are treated as column names and the current value is looked up.
+          # If hashes, they are treated as fixed values.
+          scope.inject({}) do |hash, column_or_fixed_vals|
+            if column_or_fixed_vals.is_a?(Hash)
+              fixed_vals = column_or_fixed_vals
+              hash.merge!(fixed_vals)
+            else
+              column = column_or_fixed_vals
+              hash.merge!({ column.to_sym => read_attribute(column.to_sym) })
+            end
           end
         end
 

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -80,6 +80,10 @@ class ArrayScopeListMixin < Mixin
   acts_as_list column: "pos", scope: [:parent_id, :parent_type]
 end
 
+class ArrayScopeListWithHashMixin < Mixin
+  acts_as_list column: "pos", scope: [:parent_id, state: nil]
+end
+
 if rails_4
   class EnumArrayScopeListMixin < Mixin
     STATE_VALUES = %w(active archived)
@@ -704,6 +708,20 @@ class MultipleListsArrayScopeTest < ActsAsListTestCase
     ArrayScopeListMixin.find(2).update_attributes(:parent_id => 4, :pos => 1)
     assert_equal [1, 2, 3], ArrayScopeListMixin.where(:parent_id => 1, :parent_type => 'anything').order('pos').map(&:pos)
     assert_equal [1], ArrayScopeListMixin.where(:parent_id => 4, :parent_type => 'anything').order('pos').map(&:pos)
+  end
+end
+
+class ArrayScopeListWithHashTest
+  def setup
+    setup_db
+    @obj1 = ArrayScopeListWithHashMixin.create! :pos => counter, :parent_id => 1, :state => nil
+    @obj2 = ArrayScopeListWithHashMixin.create! :pos => counter, :parent_id => 1, :state => 'anything'
+  end
+
+  def test_scope_condition_correct
+    [@obj1, @obj2].each do |obj|
+      assert_equal({ :parent_id => 1, :state => nil }, obj.scope_condition)
+    end
   end
 end
 


### PR DESCRIPTION
Hi there. Thanks for all the awesome work on this classic gem.

I'm suggesting the ability to include fixed values in the scope array so that I can ignore soft deleted items (via acts_as_paranoid). 

Someone had suggested using a string scope for this but I was encountering a bug with that when moving an object from one scope to another -- it wasn't resetting the position to 1, even though it is able to do that correctly with the identical scope but in array format.

Debugging that was going to be tough so I went for this instead, since it's nicer/more readable syntax anyway IMO. If you want me to file an issue for the bug I can do that also.

Hope you like this!