### PR TITLE
Change error classes parents

### DIFF
--- a/lib/acts_as_list/active_record/acts/no_update.rb
+++ b/lib/acts_as_list/active_record/acts/no_update.rb
@@ -7,13 +7,13 @@ module ActiveRecord
           base.extend ClassMethods
         end
 
-        class ArrayTypeError < SyntaxError
+        class ArrayTypeError < ArgumentError
           def initialize
             super("The first argument must be an array")
           end
         end
 
-        class DisparityClassesError < NotImplementedError
+        class DisparityClassesError < ArgumentError
           def initialize
             super("The first argument should contain ActiveRecord or ApplicationRecord classes")
           end


### PR DESCRIPTION
This is a fairly minor and cosmetic fix. Both  `ArrayTypeError` and `DisparityClassesError`classes should be descendants of the `StandardError` class. The best fit IMHO is `ArgumentError`.