### PR TITLE
Skip needless position-increments when creating with explicit positions

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -213,6 +213,16 @@ module ActiveRecord
 
         private
 
+        def position_in_list?(position, avoid_id = nil)
+          scope = acts_as_list_list
+
+          if avoid_id
+            scope = scope.where("#{quoted_table_name}.#{self.class.primary_key} != ?", avoid_id)
+          end
+
+          scope.where("#{quoted_position_column_with_table_name} = ?", position).exists?
+        end
+
         def swap_positions(item1, item2)
           item1_position = item1.send(position_column)
 
@@ -237,7 +247,7 @@ module ActiveRecord
           if not_in_list? || internal_scope_changed? && !position_changed || default_position?
             increment_positions_on_all_items
             self[position_column] = acts_as_list_top
-          else
+          elsif position_in_list?(self[position_column], id)
             increment_positions_on_lower_items(self[position_column], id)
           end
 
@@ -251,7 +261,7 @@ module ActiveRecord
         def add_to_list_bottom
           if not_in_list? || internal_scope_changed? && !position_changed || default_position?
             self[position_column] = bottom_position_in_list.to_i + 1
-          else
+          elsif position_in_list?(self[position_column], id)
             increment_positions_on_lower_items(self[position_column], id)
           end
 

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -887,3 +887,36 @@ class SequentialUpdatesMixinNotNullUniquePositiveConstraintsTest < ActsAsListTes
     assert_equal 3, new.pos
   end
 end
+
+class MixedPositionCreateTest < ActsAsListTestCase
+  def setup
+    setup_db
+  end
+
+  def test_reverse_position_ordering
+    item3 = DefaultScopedMixin.create pos: 3
+    item2 = DefaultScopedMixin.create pos: 2
+    item1 = DefaultScopedMixin.create pos: 1
+
+    assert_equal item3.id, 1
+    assert_equal item2.id, 2
+    assert_equal item1.id, 3
+
+    assert_equal [1, 2, 3], DefaultScopedMixin.all.map(&:pos)
+    assert_equal [3, 2, 1], DefaultScopedMixin.all.map(&:id)
+  end
+
+
+  def test_mixed_position_ordering
+    item2 = DefaultScopedMixin.create pos: 2
+    item3 = DefaultScopedMixin.create pos: 3
+    item1 = DefaultScopedMixin.create pos: 1
+
+    assert_equal item2.id, 1
+    assert_equal item3.id, 2
+    assert_equal item1.id, 3
+
+    assert_equal [1, 2, 3], DefaultScopedMixin.all.map(&:pos)
+    assert_equal [3, 1, 2], DefaultScopedMixin.all.map(&:id)
+  end
+end


### PR DESCRIPTION
This is some work in progress for #289 (see: https://github.com/swanandp/acts_as_list/issues/289#issuecomment-342457941)

There are probably a ton of tests missing to make this an actual fix.
The underlying problem is, that when inserting a new "higher" position triggers an increment of all "lower" ones (pushing them even lower). Which makes sense, if that new position would collide with an existing one. But if the spot is free, there's no need to change anything.