### PR TITLE
Use symbols instead of SQL strings for reorder (for Rails 5.2)

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -166,7 +166,7 @@ module ActiveRecord
           acts_as_list_list.
             where("#{quoted_position_column_with_table_name} <= ?", position_value).
             where("#{quoted_table_name}.#{self.class.primary_key} != ?", self.send(self.class.primary_key)).
-            reorder(position_column => :desc).
+            reorder(acts_as_list_order_argument(:desc)).
             limit(limit)
         end
 
@@ -184,7 +184,7 @@ module ActiveRecord
           acts_as_list_list.
             where("#{quoted_position_column_with_table_name} >= ?", position_value).
             where("#{quoted_table_name}.#{self.class.primary_key} != ?", self.send(self.class.primary_key)).
-            reorder(position_column => :asc).
+            reorder(acts_as_list_order_argument(:asc)).
             limit(limit)
         end
 
@@ -286,7 +286,7 @@ module ActiveRecord
             scope = scope.where("#{quoted_table_name}.#{self.class.primary_key} != ?", except.id)
           end
 
-          scope.in_list.reorder(position_column => :desc).first
+          scope.in_list.reorder(acts_as_list_order_argument(:desc)).first
         end
 
         # Forces item to assume the bottom position in the list.
@@ -358,7 +358,7 @@ module ActiveRecord
             )
 
             if sequential_updates?
-              items.reorder(position_column => :asc).each do |item|
+              items.reorder(acts_as_list_order_argument(:asc)).each do |item|
                 item.decrement!(position_column)
               end
             else
@@ -376,7 +376,7 @@ module ActiveRecord
             )
 
             if sequential_updates?
-              items.reorder(position_column => :desc).each do |item|
+              items.reorder(acts_as_list_order_argument(:desc)).each do |item|
                 item.increment!(position_column)
               end
             else
@@ -478,6 +478,14 @@ module ActiveRecord
 
         def quoted_position_column_with_table_name
           @_quoted_position_column_with_table_name ||= "#{quoted_table_name}.#{quoted_position_column}"
+        end
+
+        def acts_as_list_order_argument(direction = :asc)
+          if ActiveRecord::VERSION::MAJOR >= 4
+            { position_column => direction }
+          else
+            "#{quoted_position_column_with_table_name} #{direction.to_s.upcase}"
+          end
         end
       end
 

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -166,7 +166,7 @@ module ActiveRecord
           acts_as_list_list.
             where("#{quoted_position_column_with_table_name} <= ?", position_value).
             where("#{quoted_table_name}.#{self.class.primary_key} != ?", self.send(self.class.primary_key)).
-            reorder("#{quoted_position_column_with_table_name} DESC").
+            reorder(position_column => :desc).
             limit(limit)
         end
 
@@ -184,7 +184,7 @@ module ActiveRecord
           acts_as_list_list.
             where("#{quoted_position_column_with_table_name} >= ?", position_value).
             where("#{quoted_table_name}.#{self.class.primary_key} != ?", self.send(self.class.primary_key)).
-            reorder("#{quoted_position_column_with_table_name} ASC").
+            reorder(position_column => :asc).
             limit(limit)
         end
 
@@ -286,7 +286,7 @@ module ActiveRecord
             scope = scope.where("#{quoted_table_name}.#{self.class.primary_key} != ?", except.id)
           end
 
-          scope.in_list.reorder("#{quoted_position_column_with_table_name} DESC").first
+          scope.in_list.reorder(position_column => :desc).first
         end
 
         # Forces item to assume the bottom position in the list.
@@ -358,7 +358,7 @@ module ActiveRecord
             )
 
             if sequential_updates?
-              items.reorder("#{quoted_position_column_with_table_name} ASC").each do |item|
+              items.reorder(position_column => :asc).each do |item|
                 item.decrement!(position_column)
               end
             else
@@ -376,7 +376,7 @@ module ActiveRecord
             )
 
             if sequential_updates?
-              items.reorder("#{quoted_position_column_with_table_name} DESC").each do |item|
+              items.reorder(position_column => :desc).each do |item|
                 item.increment!(position_column)
               end
             else


### PR DESCRIPTION
Fixes #290

Passing strings to order/reorder is deprecated in Rails 5.2.

> DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "\"content_blocks\".\"position\" DESC". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql().

There was some concern in #290 about having issues with ambiguous column names. That shouldn't ever be an issue when using symbols (rails will quot it properly), and [we already have a test for it :tada:](https://github.com/swanandp/acts_as_list/blob/master/test/test_joined_list.rb)!