### PR TITLE
Unscope select.

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -226,7 +226,7 @@ module ActiveRecord
               acts_as_list_class.where(scope_condition)
             end
           else
-            acts_as_list_class.unscope(:where).where(scope_condition)
+            acts_as_list_class.unscope(:where, :select).where(scope_condition)
           end
         end
 

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -112,7 +112,7 @@ class DefaultScopedWhereMixin < Mixin
         order('pos ASC').where(active: false)
       end
     else
-      unscope(:where).where(active: false)
+      unscope(:where, :select).where(active: false)
     end
   end
 end
@@ -247,7 +247,6 @@ class ListTest < ActsAsListTestCase
 end
 
 class ListWithCallbackTest < ActsAsListTestCase
-
   include Shared::List
 
   def setup


### PR DESCRIPTION
Using `default_scope` with `select` (e.g. `default_scope { select(column_names - ['huge_data_column']) }`) along with `acts_as_list` causes error: 
`ActiveRecord::StatementInvalid: PG::UndefinedFunction: ERROR:  function count(uuid, …, timestamp without time zone) does not exist`. 

I fixed this by adding unscoping select in query used for count.