### PR TITLE
Update scope_changed? for dirty deprecation warnings

### DIFF
--- a/lib/acts_as_list/active_record/acts/scope_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/scope_method_definer.rb
@@ -17,7 +17,12 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         end
 
         define_method :scope_changed? do
-          changed.include?(scope_name.to_s)
+          if ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 1 ||
+              ActiveRecord::VERSION::MAJOR > 5
+            changed_attribute_names_to_save.include?(scope_name.to_s)
+          else
+            changed.include?(scope_name.to_s)
+          end
         end
 
         define_method :destroyed_via_scope? do


### PR DESCRIPTION
Update scope_changed? method definer for dirty deprecation warnings for ActiveRecord versions 5.1 and greater. Warning seen here: https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/attribute_methods/dirty.rb#L236. 

Should there be any test updates for this? 