### PR TITLE
mocha/minitest, not mocha/mini_test now.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,7 +13,7 @@ rescue Bundler::BundlerError => e
 end
 require "active_record"
 require "minitest/autorun"
-require "mocha/mini_test"
+require "mocha/minitest"
 require "#{File.dirname(__FILE__)}/../init"
 
 if defined?(ActiveRecord::VERSION) &&


### PR DESCRIPTION
When running in Rails 5.2, I get a warning that we should be using mocha/minitest rather than mocha/mini_test in the test helper, since the latter call signature is deprecated.  Looks like a simple fix.