### PR TITLE
Fix unique index constraint failure on item destroy

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -327,7 +327,14 @@ module ActiveRecord
         def decrement_positions_on_lower_items(position=nil)
           return unless in_list?
           position ||= send(position_column).to_i
-          acts_as_list_list.where("#{quoted_position_column_with_table_name} > ?", position).decrement_all
+
+          if sequential_updates?
+            acts_as_list_list.where("#{quoted_position_column_with_table_name} > ?", position).reorder(acts_as_list_order_argument(:asc)).each do |item|
+              item.decrement!(position_column)
+            end
+          else
+            acts_as_list_list.where("#{quoted_position_column_with_table_name} > ?", position).decrement_all
+          end
         end
 
         # Increments position (<tt>position_column</tt>) of all items in the list.

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -888,4 +888,16 @@ class SequentialUpdatesMixinNotNullUniquePositiveConstraintsTest < ActsAsListTes
     new.insert_at(3)
     assert_equal 3, new.pos
   end
+
+  def test_destroy
+    new_item = SequentialUpdatesDefault.create
+    assert_equal 5, new_item.pos
+
+    new_item.insert_at(2)
+    assert_equal 2, new_item.pos
+
+    new_item.destroy
+    assert_equal [1,2,3,4], SequentialUpdatesDefault.all.map(&:pos).sort
+
+  end
 end


### PR DESCRIPTION
Continuing on the work from #246, but this time applying the idea to the `destroy` callbacks.

With this fix, destroying an item in a list that has a unique DB constraint on the position column should not raise a DB error, as long as the `sequential_updates` option is enabled.

Fixes #267