### PR TITLE
Add touch on update configuration

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -3,6 +3,7 @@ appraise "rails-3-2" do
     gem "mysql2", "~> 0.3.21", platforms: [:ruby]
   end
   gem "activerecord", "~> 3.2.22.2"
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19]
   group :test do
     gem "after_commit_exception_notification"
   end
@@ -13,6 +14,7 @@ appraise "rails-4-1" do
     gem "mysql2", "~> 0.3.21", platforms: [:ruby]
   end
   gem "activerecord", "~> 4.1.16"
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19]
   group :test do
     gem "after_commit_exception_notification"
   end
@@ -23,6 +25,7 @@ appraise "rails-4-2" do
     gem "mysql2", "~> 0.4.10", platforms: [:ruby]
   end
   gem "activerecord", "~> 4.2.10"
+  gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 end
 
 appraise "rails-5-0" do

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake"
+gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 gem "appraisal"
 gem "activerecord", "~> 3.2.22.2"
 

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake"
+gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 gem "appraisal"
 gem "activerecord", "~> 4.1.16"
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rack", "~> 1", platforms: [:ruby_19, :ruby_20, :ruby_21]
-gem "rake"
+gem "rake", "~> 12.2.0", platforms: [:ruby_19]
 gem "appraisal"
 gem "activerecord", "~> 4.2.10"
 

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -20,13 +20,14 @@ module ActiveRecord
         #   one by one to respect position column unique not null constraint.
         #   Defaults to true if position column has unique index, otherwise false.
         #   If constraint is <tt>deferrable initially deferred<tt>, overriding it with false will speed up insert_at.
+        # * +touch_on_update+ - configuration to disable the update of the model timestamps when the positions are updated.
         def acts_as_list(options = {})
-          configuration = { column: "position", scope: "1 = 1", top_of_list: 1, add_new_at: :bottom }
+          configuration = { column: "position", scope: "1 = 1", top_of_list: 1, add_new_at: :bottom, touch_on_update: true }
           configuration.update(options) if options.is_a?(Hash)
 
           caller_class = self
 
-          ActiveRecord::Acts::List::PositionColumnMethodDefiner.call(caller_class, configuration[:column])
+          ActiveRecord::Acts::List::PositionColumnMethodDefiner.call(caller_class, configuration[:column], configuration[:touch_on_update])
           ActiveRecord::Acts::List::ScopeMethodDefiner.call(caller_class, configuration[:scope])
           ActiveRecord::Acts::List::TopOfListMethodDefiner.call(caller_class, configuration[:top_of_list])
           ActiveRecord::Acts::List::AddNewAtMethodDefiner.call(caller_class, configuration[:add_new_at])

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -328,9 +328,7 @@ module ActiveRecord
           position ||= send(position_column).to_i
 
           if sequential_updates?
-            acts_as_list_list.where("#{quoted_position_column_with_table_name} > ?", position).reorder(acts_as_list_order_argument(:asc)).each do |item|
-              item.decrement!(position_column)
-            end
+            acts_as_list_list.where("#{quoted_position_column_with_table_name} > ?", position).reorder(acts_as_list_order_argument(:asc)).decrement_sequentially
           else
             acts_as_list_list.where("#{quoted_position_column_with_table_name} > ?", position).decrement_all
           end
@@ -366,9 +364,7 @@ module ActiveRecord
             )
 
             if sequential_updates?
-              items.reorder(acts_as_list_order_argument(:asc)).each do |item|
-                item.decrement!(position_column)
-              end
+              items.reorder(acts_as_list_order_argument(:asc)).decrement_sequentially
             else
               items.decrement_all
             end
@@ -384,9 +380,7 @@ module ActiveRecord
             )
 
             if sequential_updates?
-              items.reorder(acts_as_list_order_argument(:desc)).each do |item|
-                item.increment!(position_column)
-              end
+              items.reorder(acts_as_list_order_argument(:desc)).increment_sequentially
             else
               items.increment_all
             end

--- a/lib/acts_as_list/active_record/acts/position_column_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/position_column_method_definer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord::Acts::List::PositionColumnMethodDefiner #:nodoc:
-  def self.call(caller_class, position_column)
-    define_class_methods(caller_class, position_column)
+  def self.call(caller_class, position_column, touch_on_update)
+    define_class_methods(caller_class, position_column, touch_on_update)
     define_instance_methods(caller_class, position_column)
 
     if mass_assignment_protection_was_used_by_user?(caller_class)
@@ -12,7 +12,7 @@ module ActiveRecord::Acts::List::PositionColumnMethodDefiner #:nodoc:
 
   private
 
-  def self.define_class_methods(caller_class, position_column)
+  def self.define_class_methods(caller_class, position_column, touch_on_update)
     caller_class.class_eval do
       define_singleton_method :quoted_position_column do
         @_quoted_position_column ||= connection.quote_column_name(position_column)
@@ -31,7 +31,8 @@ module ActiveRecord::Acts::List::PositionColumnMethodDefiner #:nodoc:
       end
 
       define_singleton_method :update_all_with_touch do |updates|
-        update_all(updates + touch_record_sql)
+        updates += touch_record_sql if touch_on_update
+        update_all(updates)
       end
 
       private

--- a/lib/acts_as_list/active_record/acts/position_column_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/position_column_method_definer.rb
@@ -22,6 +22,18 @@ module ActiveRecord::Acts::List::PositionColumnMethodDefiner #:nodoc:
         @_quoted_position_column_with_table_name ||= "#{caller_class.quoted_table_name}.#{quoted_position_column}"
       end
 
+      define_singleton_method :decrement_sequentially do
+        pluck(primary_key).each do |id|
+          where(primary_key => id).decrement_all
+        end
+      end
+
+      define_singleton_method :increment_sequentially do
+        pluck(primary_key).each do |id|
+          where(primary_key => id).increment_all
+        end
+      end
+
       define_singleton_method :decrement_all do
         update_all_with_touch "#{quoted_position_column} = (#{quoted_position_column_with_table_name} - 1)"
       end


### PR DESCRIPTION
In some cases, there is not a want to change the updated_at timestamp.  In my use case, I have an old record being deleted that has a low position, when that record is deleted the callback is triggered and all other items in the scope are repositioned, with an updated timestamp.

In this case the behavior is confusing. There may be a case where using `move_to_top` or `move_to_bottom` should reorder and update timestamps, but the use case I care about most is when a record is destroyed.

I could scope this setting to specify that it only has affect when `sequential_updates` is not enabled, because it only affects the `decrement_all` call here: https://github.com/mgbatchelor/acts_as_list/blob/1db1772efa716ebda76f366a5b9e86fe02cb1e9c/lib/acts_as_list/active_record/acts/list.rb#L335

Please advise. Thanks