### PR TITLE
Add gem version badge to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Build Status
 [![Build Status](https://secure.travis-ci.org/swanandp/acts_as_list.png)](https://secure.travis-ci.org/swanandp/acts_as_list)
+[![Gem Version](https://badge.fury.io/rb/acts_as_list.svg)](https://badge.fury.io/rb/acts_as_list)
 
 ## Description
 


### PR DESCRIPTION
Useful to quickly check what the latest published version is and compare it to your own, etc.

![screenshot 2019-01-28 09 45 30](https://user-images.githubusercontent.com/180819/51851710-ab64b280-22e1-11e9-98e7-3a75c54948f1.png)
