### PR TITLE
Add Deadlock Error Troubleshooting to README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added *Troubleshooting Database Deadlock Errors* section to `README.md`
 
 ## [0.9.19] - 2019-03-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,6 +181,72 @@ TodoItem.acts_as_list_no_update([TodoAttachment]) do
 end
 ```
 
+## Troubleshooting Database Deadlock Errors
+When using this gem in an app with a high amount of concurrency, you may see "deadlock" errors raised by your database server.
+It's difficult for the gem to provide a solution that fits every app. 
+Here are some steps you can take to mitigate and handle these kinds of errors.
+
+### 1) Use the Most Concise API
+One easy way to reduce deadlocks is to use the most concise gem API available for what you want to accomplish.
+In this specific example, the more concise API for creating a list item at a position results in one transaction instead of two,
+and it issues fewer SQL statements. Issuing fewer statements tends to lead to faster transactions.
+Faster transactions are less likely to deadlock.
+
+Example:
+```ruby
+# Good
+TodoItem.create(todo_list: todo_list, position: 1)
+
+# Bad
+item = TodoItem.create(todo_list: todo_list)
+item.insert_at(1)
+```
+
+### 2) Rescue then Retry
+Deadlocks are always a possibility when updating tables rows concurrently. 
+The general advice from MySQL documentation is to catch these errors and simply retry the transaction; it will probably succeed on another attempt. (see [How to Minimize and Handle Deadlocks](https://dev.mysql.com/doc/refman/8.0/en/innodb-deadlocks-handling.html))
+Retrying transactions sounds simple, but there are many details that need to be chosen on a per-app basis:
+How many retry attempts should be made?
+Should there be a wait time between attemps?
+What _other_ statements were in the transaction that got rolled back?
+
+Here a simple example of rescuing from deadlock and retrying the operation:
+*  `ActiveRecord::Deadlocked` is avilable in Rails >= 5.1.0.
+* If you have Rails < 5.1.0, you will need to rescue `ActiveRecord::StatementInvalid` and check `#cause`.
+```ruby
+  attempts_left = 2
+  while attempts_left > 0
+    attempts_left -= 1
+    begin
+      TodoItem.transaction do
+        TodoItem.create(todo_list: todo_list, position: 1)
+      end
+      attempts_left = 0
+    rescue ActiveRecord::Deadlocked
+      raise unless attempts_left > 0
+    end
+  end
+```
+
+You can also use the approach suggested in this StackOverflow post:
+https://stackoverflow.com/questions/4027659/activerecord3-deadlock-retry
+
+### 3) Lock Parent Record
+In additon to reacting to deadlocks, it is possible to reduce their frequency with more pessimistic locking. 
+This approach uses the parent record as a mutex for the entire list.
+This kind of locking is very effective at reducing the frequency of deadlocks while updating list items.
+However, there are some things to keep in mind:
+* This locking pattern needs to be used around *every* call that modifies the list; even if it does not reorder list items.
+* This locking pattern effectively serializes operations on the list. The throughput of operations on the list will decrease.
+* Locking the parent record may lead to deadlock elsewhere if some other code also locks the parent table.
+
+Example:
+```ruby
+todo_list = TodoList.create(name: "The List")
+todo_list.with_lock do
+  item = TodoItem.create(description: "Buy Groceries", todo_list: todo_list, position: 1)
+end
+
 ## Versions
 Version `0.9.0` adds `acts_as_list_no_update` (https://github.com/swanandp/acts_as_list/pull/244) and compatibility with not-null and uniqueness constraints on the database (https://github.com/swanandp/acts_as_list/pull/246). These additions shouldn't break compatibility with existing implementations.
 


### PR DESCRIPTION
This pull request adds a section of troubleshooting advice to README.md. This section helps users of the gem mitigate or handle deadlock errors which can occur when using the gem in a concurrent application.

This documentation was created as a response to #337 and addresses similar concerns as #325.

@brendon