### PR TITLE
Expose configuration via class-level method and fixes EnumArrayScopeListMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Expose configuration via class-level method (acts_as_list_options) [\#447](https://github.com/brendon/acts_as_list/pull/447) ([anthony0030])
+
 ## v1.2.5 - 2025-10-21
 
 - Fix crash when deleting an association with composite primary keys [\#450](https://github.com/brendon/acts_as_list/pull/450) ([smathieu])

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -27,6 +27,11 @@ module ActiveRecord
           configuration = { column: "position", scope: "1 = 1", top_of_list: 1, add_new_at: :bottom, touch_on_update: true }
           configuration.update(options) if options.is_a?(Hash)
 
+          # * Expose configuration via class-level method
+          define_singleton_method(:acts_as_list_options) do
+            configuration.dup.freeze
+          end
+
           caller_class = self
 
           ActiveRecord::Acts::List::PositionColumnMethodDefiner.call(caller_class, configuration[:column], configuration[:touch_on_update])

--- a/test/test_acts_as_list_options.rb
+++ b/test/test_acts_as_list_options.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+class ActsAsListOptionsTest
+  def setup
+    setup_db
+  end
+
+  def test_acts_as_list_options_returns_the_macro_configuration # rubocop:disable Metrics/MethodLength
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = 'mixins'
+      acts_as_list(
+        column: :pos,
+        scope: %i[parent_id parent_type],
+        add_new_at: :top,
+        top_of_list: 0,
+        touch_on_update: false
+      )
+    end
+
+    opts = klass.acts_as_list_options
+
+    assert_equal %i[parent_id parent_type], opts[:scope]
+    assert_equal :pos,                       opts[:column]
+    assert_equal :top,                       opts[:add_new_at]
+    assert_equal 0,                          opts[:top_of_list]
+    assert_equal false,                      opts[:touch_on_update]
+    assert_equal true,                       opts.frozen?
+  end
+end


### PR DESCRIPTION
On a project I'm working on, we need access to the config for the acts_as_list.
I also made sure all the tests are successful and added the appropriate tests for the new functionality that this PR adds.
It took me some time to get the DB to function, I used sqlite.
It would be great if there was some official documentation on how to set up the dev environment.
If you need any adjustments to this PR, please let me know, and I will make them ASAP.

If you accept this PR, please also publish it to Gemhub so my colleagues can easily use it.